### PR TITLE
Collect verifier events to database

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-extra-semi": "off",
     "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-unused-vars": ["warn", { "varsIgnorePattern": "_" }],
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error"
   },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,10 @@
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/no-extra-semi": "off",
     "@typescript-eslint/no-empty-function": "off",
-    "@typescript-eslint/no-unused-vars": ["warn", { "varsIgnorePattern": "_" }],
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      { "varsIgnorePattern": "_", "argsIgnorePattern": "_" }
+    ],
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error"
   },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -35,6 +35,7 @@
     "@sinonjs/fake-timers": "^7.1.2",
     "@types/supertest": "^2.0.11",
     "conditional-type-checks": "^1.0.5",
+    "earljs": "^0.1.12",
     "supertest": "^6.1.6",
     "wait-for-expect": "^3.0.2"
   }

--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -64,7 +64,7 @@ export class Application {
       safeBlockService,
       dataSyncService,
       logger,
-      config.core.sync.batchSize
+      config.core.syncBatchSize
     )
 
     // #endregion core

--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -63,7 +63,8 @@ export class Application {
       syncStatusRepository,
       safeBlockService,
       dataSyncService,
-      logger
+      logger,
+      config.core.sync.batchSize
     )
 
     // #endregion core

--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -7,10 +7,12 @@ import { DataSyncService } from './core/DataSyncService'
 import { SafeBlockService } from './core/SafeBlockService'
 import { StatusService } from './core/StatusService'
 import { SyncScheduler } from './core/SyncScheduler'
+import { VerifierCollector } from './core/VerifierCollector'
 import { DatabaseService } from './peripherals/database/DatabaseService'
 import { KeyValueStore } from './peripherals/database/KeyValueStore'
 import { PositionUpdateRepository } from './peripherals/database/PositionUpdateRepository'
 import { SyncStatusRepository } from './peripherals/database/SyncStatusRepository'
+import { VerifierEventRepository } from './peripherals/database/VerifierEventRepository'
 import { EthereumClient } from './peripherals/ethereum/EthereumClient'
 import { Logger } from './tools/Logger'
 
@@ -32,6 +34,8 @@ export class Application {
     const syncStatusRepository = new SyncStatusRepository(kvStore)
     // @todo unused for now
     new PositionUpdateRepository(knex, logger)
+    const verifierEventRepository = new VerifierEventRepository(knex, logger)
+
     const ethereumClient = new EthereumClient(config.jsonRpcUrl)
 
     // #endregion peripherals
@@ -49,7 +53,12 @@ export class Application {
       safeBlockService,
     })
 
-    const dataSyncService = new DataSyncService()
+    const verifierCollector = new VerifierCollector(
+      ethereumClient,
+      verifierEventRepository
+    )
+
+    const dataSyncService = new DataSyncService(verifierCollector, logger)
     const syncScheduler = new SyncScheduler(
       syncStatusRepository,
       safeBlockService,
@@ -74,6 +83,7 @@ export class Application {
       await databaseService.migrateToLatest()
 
       await apiServer.listen()
+      await safeBlockService.start()
       await syncScheduler.start()
 
       logger.for(this).info('Started')

--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -14,8 +14,6 @@ export interface Config {
       refreshIntervalMs: number
       blockOffset: number
     }
-    sync: {
-      batchSize: number
-    }
+    syncBatchSize: number
   }
 }

--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -14,5 +14,8 @@ export interface Config {
       refreshIntervalMs: number
       blockOffset: number
     }
+    sync: {
+      batchSize: number
+    }
   }
 }

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -20,6 +20,9 @@ export function getLocalConfig(): Config {
         refreshIntervalMs: 1 * 60 * 1000,
         blockOffset: 100,
       },
+      sync: {
+        batchSize: getEnv.integer('SYNC_BATCH_SIZE', 6_000),
+      },
     },
   }
 }

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -20,9 +20,7 @@ export function getLocalConfig(): Config {
         refreshIntervalMs: 1 * 60 * 1000,
         blockOffset: 100,
       },
-      sync: {
-        batchSize: getEnv.integer('SYNC_BATCH_SIZE', 6_000),
-      },
+      syncBatchSize: getEnv.integer('SYNC_BATCH_SIZE', 6_000),
     },
   }
 }

--- a/packages/backend/src/config/config.production.ts
+++ b/packages/backend/src/config/config.production.ts
@@ -17,6 +17,9 @@ export function getProductionConfig(): Config {
         refreshIntervalMs: 5 * 60 * 1000,
         blockOffset: 100,
       },
+      sync: {
+        batchSize: getEnv.integer('SYNC_BATCH_SIZE', 6_000),
+      },
     },
   }
 }

--- a/packages/backend/src/config/config.production.ts
+++ b/packages/backend/src/config/config.production.ts
@@ -17,9 +17,7 @@ export function getProductionConfig(): Config {
         refreshIntervalMs: 5 * 60 * 1000,
         blockOffset: 100,
       },
-      sync: {
-        batchSize: getEnv.integer('SYNC_BATCH_SIZE', 6_000),
-      },
+      syncBatchSize: getEnv.integer('SYNC_BATCH_SIZE', 6_000),
     },
   }
 }

--- a/packages/backend/src/config/config.testing.ts
+++ b/packages/backend/src/config/config.testing.ts
@@ -19,6 +19,9 @@ export function getTestConfig(): Config {
     jsonRpcUrl: getEnv('TEST_JSON_RPC_URL', 'http://localhost:8545'),
     core: throwsOnUnexpectedAccess({
       safeBlock: UNEXPECTED_ACCESS,
+      sync: {
+        batchSize: 6_000,
+      },
     }),
   }
 }

--- a/packages/backend/src/config/config.testing.ts
+++ b/packages/backend/src/config/config.testing.ts
@@ -19,9 +19,7 @@ export function getTestConfig(): Config {
     jsonRpcUrl: getEnv('TEST_JSON_RPC_URL', 'http://localhost:8545'),
     core: throwsOnUnexpectedAccess({
       safeBlock: UNEXPECTED_ACCESS,
-      sync: {
-        batchSize: 6_000,
-      },
+      syncBatchSize: 6_000,
     }),
   }
 }

--- a/packages/backend/src/core/DataSyncService.ts
+++ b/packages/backend/src/core/DataSyncService.ts
@@ -1,4 +1,4 @@
-import { BlockRange } from '../peripherals/ethereum/types'
+import { BlockNumber, BlockRange } from '../peripherals/ethereum/types'
 import { Logger } from '../tools/Logger'
 import { VerifierCollector } from './VerifierCollector'
 
@@ -20,7 +20,7 @@ export class DataSyncService {
     })
   }
 
-  async revert() {
+  async revert(_blockNumber: BlockNumber) {
     this.logger.error(`Method .revert() not implemented`)
   }
 }

--- a/packages/backend/src/core/DataSyncService.ts
+++ b/packages/backend/src/core/DataSyncService.ts
@@ -1,11 +1,26 @@
 import { BlockRange } from '../peripherals/ethereum/types'
+import { Logger } from '../tools/Logger'
+import { VerifierCollector } from './VerifierCollector'
 
 export class DataSyncService {
+  constructor(
+    private readonly verifierCollector: VerifierCollector,
+    private readonly logger: Logger
+  ) {
+    this.logger = logger.for(this)
+  }
+
   async sync(blockRange: BlockRange) {
-    console.log('sync', blockRange)
+    const verifiers = await this.verifierCollector.collect(blockRange)
+
+    this.logger.info({
+      method: 'sync',
+      blockRange,
+      verifiers: verifiers.map(String),
+    })
   }
 
   async revert() {
-    throw new Error('Method not implemented.')
+    this.logger.error(`Method .revert() not implemented`)
   }
 }

--- a/packages/backend/src/core/DataSyncService.ts
+++ b/packages/backend/src/core/DataSyncService.ts
@@ -20,7 +20,8 @@ export class DataSyncService {
     })
   }
 
-  async revert(_blockNumber: BlockNumber) {
+  async revert(blockNumber: BlockNumber) {
+    await this.verifierCollector.discard({ from: blockNumber })
     this.logger.error(`Method .revert() not implemented`)
   }
 }

--- a/packages/backend/src/core/SyncScheduler.ts
+++ b/packages/backend/src/core/SyncScheduler.ts
@@ -7,7 +7,7 @@ import { DataSyncService } from './DataSyncService'
 import { SafeBlockService } from './SafeBlockService'
 
 /** max synced blockRange length */
-const BATCH_SIZE = 500
+const BATCH_SIZE = 10000
 
 export class SyncScheduler {
   constructor(

--- a/packages/backend/src/core/SyncScheduler.ts
+++ b/packages/backend/src/core/SyncScheduler.ts
@@ -27,7 +27,7 @@ export class SyncScheduler {
 
     this.logger.info('Last block number synced', { last })
 
-    await this.dataSyncService.revert()
+    await this.dataSyncService.revert(last)
 
     this.safeBlockService.onNewSafeBlock(({ blockNumber }) => {
       if (blockNumber > last) {
@@ -61,8 +61,13 @@ export class SyncScheduler {
   }
 
   private async sync(blockRange: BlockRange) {
-    this.logger.info({ method: 'sync', blockRange })
-    await this.dataSyncService.sync(blockRange)
-    await this.statusRepository.setLastBlockNumberSynced(blockRange.to)
+    try {
+      this.logger.info({ method: 'sync', blockRange })
+      await this.dataSyncService.sync(blockRange)
+      await this.statusRepository.setLastBlockNumberSynced(blockRange.to)
+    } catch (err) {
+      this.dataSyncService.revert(blockRange.from)
+      throw err
+    }
   }
 }

--- a/packages/backend/src/core/SyncScheduler.ts
+++ b/packages/backend/src/core/SyncScheduler.ts
@@ -6,16 +6,13 @@ import { Logger } from '../tools/Logger'
 import { DataSyncService } from './DataSyncService'
 import { SafeBlockService } from './SafeBlockService'
 
-/** max synced blockRange length */
-const BATCH_SIZE = 10000
-
 export class SyncScheduler {
   constructor(
     private readonly statusRepository: SyncStatusRepository,
     private readonly safeBlockService: SafeBlockService,
     private readonly dataSyncService: DataSyncService,
     private readonly logger: Logger,
-    private readonly batchSize = BATCH_SIZE
+    private readonly batchSize: number
   ) {
     this.logger = logger.for(this)
   }

--- a/packages/backend/src/core/VerifierCollector.ts
+++ b/packages/backend/src/core/VerifierCollector.ts
@@ -35,8 +35,7 @@ export class VerifierCollector {
   async collect(blockRange: BlockRange): Promise<EthereumAddress[]> {
     const oldEvents = this.verifierEventRepository.getAll()
     const newEvents = await this.getEvents(blockRange)
-    const savingNewEventsToDb =
-      this.verifierEventRepository.addOrUpdate(newEvents)
+    const savingNewEventsToDb = this.verifierEventRepository.add(newEvents)
 
     const events = [...(await oldEvents), ...newEvents]
     const [upgraded, added] = partitionVerifierEvents(events)

--- a/packages/backend/src/core/VerifierCollector.ts
+++ b/packages/backend/src/core/VerifierCollector.ts
@@ -9,7 +9,7 @@ import {
   VerifierEventRepository,
 } from '../peripherals/database/VerifierEventRepository'
 import { EthereumClient } from '../peripherals/ethereum/EthereumClient'
-import { BlockRange } from '../peripherals/ethereum/types'
+import { BlockNumber, BlockRange } from '../peripherals/ethereum/types'
 import { partition } from '../tools/partition'
 
 const PROXY_ADDRESS = '0xC8c212f11f6ACca77A7afeB7282dEBa5530eb46C'
@@ -45,6 +45,10 @@ export class VerifierCollector {
     await savingNewEventsToDb
 
     return computeVerifiersFromEvents(added, upgraded)
+  }
+
+  async discard({ from }: { from: BlockNumber }) {
+    await this.verifierEventRepository.deleteAllAfter(from - 1)
   }
 
   private async getEvents(blockRange: BlockRange) {

--- a/packages/backend/src/core/VerifierCollector.ts
+++ b/packages/backend/src/core/VerifierCollector.ts
@@ -1,0 +1,123 @@
+import { utils } from 'ethers'
+import { AbiCoder } from 'ethers/lib/utils'
+
+import { EthereumAddress } from '../model'
+import {
+  ImplementationAddedEventRecord,
+  UpgradedEventRecord,
+  VerifierEventRecord,
+  VerifierEventRepository,
+} from '../peripherals/database/VerifierEventRepository'
+import { EthereumClient } from '../peripherals/ethereum/EthereumClient'
+import { BlockRange } from '../peripherals/ethereum/types'
+import { partition } from '../tools/partition'
+
+const PROXY_ADDRESS = '0xC8c212f11f6ACca77A7afeB7282dEBa5530eb46C'
+
+const PROXY_ABI = new utils.Interface([
+  'event ImplementationAdded(address indexed implementation, bytes initializer, bool finalize)',
+  'event Upgraded(address indexed implementation)',
+])
+
+const Upgraded = PROXY_ABI.getEventTopic('Upgraded')
+const ImplementationAdded = PROXY_ABI.getEventTopic('ImplementationAdded')
+
+export class VerifierCollector {
+  constructor(
+    private readonly ethereumClient: Pick<EthereumClient, 'getLogs'>,
+    private readonly verifierEventRepository: VerifierEventRepository
+  ) {}
+
+  /**
+   * Saves new `Upgraded` and `ImplementationAdded` events to the database,
+   * and returns verifier addresses derived from both the old and new events.
+   */
+  async collect(blockRange: BlockRange): Promise<EthereumAddress[]> {
+    const oldEvents = this.verifierEventRepository.getAll()
+    const newEvents = this.getEvents(blockRange)
+    const savingNewEventsToDb = newEvents.then((events) =>
+      this.verifierEventRepository.addOrUpdate(events)
+    )
+
+    const [oldUpgraded, oldAdded] = partitionVerifierEvents(await oldEvents)
+    const [newUpgraded, newAdded] = partitionVerifierEvents(await newEvents)
+
+    oldAdded.sort(byBlockNumberDescending)
+    newAdded.sort(byBlockNumberDescending)
+
+    // verifiers we already knew about
+    const oldVerifiers = computeVerifiersFromEvents(oldAdded, oldUpgraded)
+
+    // verifiers upgraded in the block range
+    const newVerifiers = computeVerifiersFromEvents(
+      [...oldAdded, ...newAdded],
+      newUpgraded
+    )
+
+    await savingNewEventsToDb
+
+    return [...oldVerifiers, ...newVerifiers]
+  }
+
+  private async getEvents(blockRange: BlockRange) {
+    const logs = await this.ethereumClient.getLogs({
+      address: PROXY_ADDRESS,
+      fromBlock: blockRange.from,
+      toBlock: blockRange.to,
+      topics: [[ImplementationAdded, Upgraded]],
+    })
+
+    const events = logs.map((log): VerifierEventRecord => {
+      const event = PROXY_ABI.parseLog(log)
+      return {
+        name: event.name as 'ImplementationAdded' | 'Upgraded',
+        blockNumber: log.blockNumber,
+        implementation: event.args.implementation,
+        initializer: event.args.initializer,
+      }
+    })
+
+    return events
+  }
+}
+
+/**
+ * ImplementationAdded and Upgraded events are the source of truth for verifiers
+ * which addresses are found in the `upgradeEvent.initializer` field.
+ */
+function computeVerifiersFromEvents(
+  added: ImplementationAddedEventRecord[],
+  upgraded: UpgradedEventRecord[]
+): EthereumAddress[] {
+  return upgraded
+    .map(
+      // get closest preceding added event with the same implementation
+      (u) =>
+        added.find(
+          (a) =>
+            a.implementation === u.implementation &&
+            a.blockNumber <= u.blockNumber
+        )
+    )
+    .filter((x): x is ImplementationAddedEventRecord => x !== undefined)
+    .map((x) => decodeAddress(x.initializer))
+}
+
+function decodeAddress(data: string): EthereumAddress {
+  const decoded = new AbiCoder().decode(['address'], data)[0]
+  return EthereumAddress(decoded)
+}
+
+function partitionVerifierEvents(events: VerifierEventRecord[]) {
+  return partition(
+    events,
+    (e): e is UpgradedEventRecord => e.name === 'Upgraded'
+  )
+}
+
+function byBlockNumberDescending(
+  a: { blockNumber: number },
+  b: { blockNumber: number }
+) {
+  return b.blockNumber - a.blockNumber
+}

--- a/packages/backend/src/model/EthereumAddress.ts
+++ b/packages/backend/src/model/EthereumAddress.ts
@@ -1,0 +1,26 @@
+import { constants, utils } from 'ethers'
+
+export interface EthereumAddress extends String {
+  _ethereumAddressBrand: string
+}
+
+export function EthereumAddress(value: string) {
+  try {
+    return utils.getAddress(value) as unknown as EthereumAddress
+  } catch {
+    throw new TypeError('Invalid EthereumAddress')
+  }
+}
+
+EthereumAddress.ZERO = EthereumAddress(constants.AddressZero)
+
+EthereumAddress.isBefore = function (a: EthereumAddress, b: EthereumAddress) {
+  return a.toLowerCase() < b.toLowerCase()
+}
+
+EthereumAddress.inOrder = function (
+  a: EthereumAddress,
+  b: EthereumAddress
+): [EthereumAddress, EthereumAddress] {
+  return EthereumAddress.isBefore(a, b) ? [a, b] : [b, a]
+}

--- a/packages/backend/src/model/index.ts
+++ b/packages/backend/src/model/index.ts
@@ -1,1 +1,2 @@
+export * from './EthereumAddress'
 export * from './json'

--- a/packages/backend/src/peripherals/database/DatabaseService.ts
+++ b/packages/backend/src/peripherals/database/DatabaseService.ts
@@ -38,17 +38,19 @@ export class DatabaseService {
   }
 
   async migrateToLatest() {
+    const oldVersion = await this.knex.migrate.currentVersion()
     await this.knex.migrate.latest()
     const version = await this.knex.migrate.currentVersion()
     this.migrated = true
     this.version = version
-    this.logger.info('Migrations completed', { version })
+    this.logger.info('Migrations completed', { oldVersion, version })
   }
 
   async rollbackAll() {
     this.migrated = false
     this.version = null
     await this.knex.migrate.rollback(undefined, true)
+    this.logger.info('Rollback completed')
   }
 
   async closeConnection() {

--- a/packages/backend/src/peripherals/database/PositionUpdateRepository.ts
+++ b/packages/backend/src/peripherals/database/PositionUpdateRepository.ts
@@ -25,12 +25,16 @@ export class PositionUpdateRepository
   }
 
   async addOrUpdate(records: PositionUpdateRecord[]) {
+    if (records.length === 0)
+      return this.logger.debug({ method: 'addOrUpdate', rows: 0 })
+
     const rows: PositionUpdateRow[] = records.map(toRow)
     await this.knex('position_updates')
       .insert(rows)
       .onConflict(['position_id'])
       .merge()
-    this.logger.debug({ method: 'add', rows: rows.length })
+
+    this.logger.debug({ method: 'addOrUpdate', rows: rows.length })
   }
 
   async getAll() {

--- a/packages/backend/src/peripherals/database/PositionUpdateRepository.ts
+++ b/packages/backend/src/peripherals/database/PositionUpdateRepository.ts
@@ -25,8 +25,10 @@ export class PositionUpdateRepository
   }
 
   async addOrUpdate(records: PositionUpdateRecord[]) {
-    if (records.length === 0)
-      return this.logger.debug({ method: 'addOrUpdate', rows: 0 })
+    if (records.length === 0) {
+      this.logger.debug({ method: 'addOrUpdate', rows: 0 })
+      return
+    }
 
     const rows: PositionUpdateRow[] = records.map(toRow)
     await this.knex('position_updates')

--- a/packages/backend/src/peripherals/database/VerifierEventRepository.ts
+++ b/packages/backend/src/peripherals/database/VerifierEventRepository.ts
@@ -53,7 +53,7 @@ export class VerifierEventRepository
 
   async getAllAfter(blockNumber: number) {
     const rows = await this.knex('verifier_events')
-      .where('blockNumber', '>', blockNumber)
+      .where('block_number', '>', blockNumber)
       .select('*')
     this.logger.debug({ method: 'getAllAfter', rows: rows.length })
 
@@ -67,7 +67,7 @@ export class VerifierEventRepository
 
   async deleteAllAfter(blockNumber: number) {
     const rowsCount = await this.knex('verifier_events')
-      .where('blockNumber', '>', blockNumber)
+      .where('block_number', '>', blockNumber)
       .delete()
     this.logger.debug({ method: 'deleteAllAfter', rows: rowsCount })
   }

--- a/packages/backend/src/peripherals/database/VerifierEventRepository.ts
+++ b/packages/backend/src/peripherals/database/VerifierEventRepository.ts
@@ -47,12 +47,29 @@ export class VerifierEventRepository
   async getAll() {
     const rows = await this.knex('verifier_events').select('*')
     this.logger.debug({ method: 'getAll', rows: rows.length })
+
+    return rows.map(toRecord)
+  }
+
+  async getAllAfter(blockNumber: number) {
+    const rows = await this.knex('verifier_events')
+      .where('blockNumber', '>', blockNumber)
+      .select('*')
+    this.logger.debug({ method: 'getAllAfter', rows: rows.length })
+
     return rows.map(toRecord)
   }
 
   async deleteAll() {
     await this.knex('verifier_events').delete()
     this.logger.debug({ method: 'deleteAll' })
+  }
+
+  async deleteAllAfter(blockNumber: number) {
+    const rowsCount = await this.knex('verifier_events')
+      .where('blockNumber', '>', blockNumber)
+      .delete()
+    this.logger.debug({ method: 'deleteAllAfter', rows: rowsCount })
   }
 }
 

--- a/packages/backend/src/peripherals/database/VerifierEventRepository.ts
+++ b/packages/backend/src/peripherals/database/VerifierEventRepository.ts
@@ -31,21 +31,17 @@ export class VerifierEventRepository
     this.logger = this.logger.for(this)
   }
 
-  async addOrUpdate(records: VerifierEventRecord[]) {
+  async add(records: VerifierEventRecord[]) {
     if (records.length === 0) {
-      this.logger.debug({ method: 'addOrUpdate', rows: 0 })
+      this.logger.debug({ method: 'add', rows: 0 })
       return
     }
 
     const rows: VerifierEventRow[] = records.map(toRow)
-    const primaryKey: keyof VerifierEventRow = 'id'
 
-    await this.knex('verifier_events')
-      .insert(rows)
-      .onConflict([primaryKey])
-      .merge()
+    await this.knex('verifier_events').insert(rows)
 
-    this.logger.debug({ method: 'addOrUpdate', rows: rows.length })
+    this.logger.debug({ method: 'add', rows: rows.length })
   }
 
   async getAll() {

--- a/packages/backend/src/peripherals/database/VerifierEventRepository.ts
+++ b/packages/backend/src/peripherals/database/VerifierEventRepository.ts
@@ -51,15 +51,6 @@ export class VerifierEventRepository
     return rows.map(toRecord)
   }
 
-  async getAllAfter(blockNumber: number) {
-    const rows = await this.knex('verifier_events')
-      .where('block_number', '>', blockNumber)
-      .select('*')
-    this.logger.debug({ method: 'getAllAfter', rows: rows.length })
-
-    return rows.map(toRecord)
-  }
-
   async deleteAll() {
     await this.knex('verifier_events').delete()
     this.logger.debug({ method: 'deleteAll' })

--- a/packages/backend/src/peripherals/database/VerifierEventRepository.ts
+++ b/packages/backend/src/peripherals/database/VerifierEventRepository.ts
@@ -32,8 +32,10 @@ export class VerifierEventRepository
   }
 
   async addOrUpdate(records: VerifierEventRecord[]) {
-    if (records.length === 0)
-      return this.logger.debug({ method: 'addOrUpdate', rows: 0 })
+    if (records.length === 0) {
+      this.logger.debug({ method: 'addOrUpdate', rows: 0 })
+      return
+    }
 
     const rows: VerifierEventRow[] = records.map(toRow)
     const primaryKey: keyof VerifierEventRow = 'id'

--- a/packages/backend/src/peripherals/database/VerifierEventRepository.ts
+++ b/packages/backend/src/peripherals/database/VerifierEventRepository.ts
@@ -1,0 +1,104 @@
+import { Knex } from 'knex'
+import { VerifierEventRow } from 'knex/types/tables'
+
+import { Logger } from '../../tools/Logger'
+import { Repository } from './types'
+
+export type VerifierEventRecord = (
+  | ImplementationAddedEventRecord
+  | UpgradedEventRecord
+) & {
+  id?: number
+}
+
+export interface ImplementationAddedEventRecord {
+  implementation: string
+  initializer: string
+  blockNumber: number
+  name: 'ImplementationAdded'
+}
+
+export interface UpgradedEventRecord {
+  implementation: string
+  blockNumber: number
+  name: 'Upgraded'
+}
+
+export class VerifierEventRepository
+  implements Repository<VerifierEventRecord>
+{
+  constructor(private readonly knex: Knex, private readonly logger: Logger) {
+    this.logger = this.logger.for(this)
+  }
+
+  async addOrUpdate(records: VerifierEventRecord[]) {
+    if (records.length === 0)
+      return this.logger.debug({ method: 'addOrUpdate', rows: 0 })
+
+    const rows: VerifierEventRow[] = records.map(toRow)
+    const primaryKey: keyof VerifierEventRow = 'id'
+
+    await this.knex('verifier_events')
+      .insert(rows)
+      .onConflict([primaryKey])
+      .merge()
+
+    this.logger.debug({ method: 'addOrUpdate', rows: rows.length })
+  }
+
+  async getAll() {
+    const rows = await this.knex('verifier_events').select('*')
+    this.logger.debug({ method: 'getAll', rows: rows.length })
+    return rows.map(toRecord)
+  }
+
+  async deleteAll() {
+    await this.knex('verifier_events').delete()
+    this.logger.debug({ method: 'deleteAll' })
+  }
+}
+
+function toRow(record: VerifierEventRecord): VerifierEventRow {
+  switch (record.name) {
+    case 'ImplementationAdded':
+      return {
+        id: record.id,
+        block_number: record.blockNumber,
+        implementation: record.implementation,
+        initializer: record.initializer,
+        name: 'ImplementationAdded',
+      }
+    case 'Upgraded':
+      return {
+        id: record.id,
+        block_number: record.blockNumber,
+        implementation: record.implementation,
+        name: 'Upgraded',
+      }
+  }
+}
+
+function toRecord(row: VerifierEventRow): VerifierEventRecord {
+  switch (row.name) {
+    case 'ImplementationAdded':
+      if (!row.initializer)
+        throw new Error(
+          "'initializer' is required on ImplmenedationAdded event"
+        )
+
+      return {
+        id: row.id,
+        implementation: row.implementation,
+        initializer: row.initializer,
+        blockNumber: row.block_number,
+        name: 'ImplementationAdded',
+      }
+    case 'Upgraded':
+      return {
+        id: row.id,
+        implementation: row.implementation,
+        blockNumber: row.block_number,
+        name: 'Upgraded',
+      }
+  }
+}

--- a/packages/backend/src/peripherals/database/migrations/003_verifier_events.ts
+++ b/packages/backend/src/peripherals/database/migrations/003_verifier_events.ts
@@ -24,5 +24,5 @@ export async function up(knex: Knex) {
 }
 
 export async function down(knex: Knex) {
-  await knex.schema.dropTable('key_values')
+  await knex.schema.dropTable('verifier_events')
 }

--- a/packages/backend/src/peripherals/database/migrations/003_verifier_events.ts
+++ b/packages/backend/src/peripherals/database/migrations/003_verifier_events.ts
@@ -1,0 +1,28 @@
+/*
+                      ====== IMPORTANT NOTICE ======
+
+DO NOT EDIT OR RENAME THIS FILE
+
+This is a migration file. Once created the file should not be renamed or edited,
+because migrations are only run once on the production server. 
+
+If you find that something was incorrectly set up in the `up` function you
+should create a new migration file that fixes the issue.
+
+*/
+
+import { Knex } from 'knex'
+
+export async function up(knex: Knex) {
+  await knex.schema.createTable('verifier_events', (table) => {
+    table.increments('id').primary()
+    table.integer('block_number').notNullable()
+    table.string('implementation').notNullable()
+    table.enum('name', ['ImplementationAdded', 'Upgraded']).notNullable()
+    table.string('initializer').nullable()
+  })
+}
+
+export async function down(knex: Knex) {
+  await knex.schema.dropTable('key_values')
+}

--- a/packages/backend/src/peripherals/database/types.ts
+++ b/packages/backend/src/peripherals/database/types.ts
@@ -38,7 +38,8 @@ declare module 'knex/types/tables' {
 }
 
 export interface Repository<TRecord> {
-  addOrUpdate(records: TRecord[]): Promise<void>
+  addOrUpdate?(records: TRecord[]): Promise<void>
+  add?(records: TRecord[]): Promise<void>
   getAll(): Promise<TRecord[]>
   deleteAll(): Promise<void>
 }

--- a/packages/backend/src/peripherals/database/types.ts
+++ b/packages/backend/src/peripherals/database/types.ts
@@ -19,9 +19,21 @@ declare module 'knex/types/tables' {
     value: string
   }
 
+  interface VerifierEventRow {
+    /**
+     * surrogate key
+     */
+    id?: number
+    implementation: string
+    block_number: number
+    name: 'ImplementationAdded' | 'Upgraded'
+    initializer?: string
+  }
+
   interface Tables {
     position_updates: PositionUpdateRow
     key_values: KeyValueRow
+    verifier_events: VerifierEventRow
   }
 }
 

--- a/packages/backend/src/tools/JobQueue.ts
+++ b/packages/backend/src/tools/JobQueue.ts
@@ -59,7 +59,7 @@ export class JobQueue {
       await job.execute()
       this.inProgress.splice(this.inProgress.indexOf(job), 1)
     } catch (error) {
-      this.logger.error(error, `Job "${job.name}" failed with:`)
+      this.logger.error(`Job "${job.name}" failed with:`, error)
       this.inProgress.splice(this.inProgress.indexOf(job), 1)
       this.queue.unshift({ ...job, failureCount: job.failureCount + 1 })
     } finally {

--- a/packages/backend/src/tools/JobQueue.ts
+++ b/packages/backend/src/tools/JobQueue.ts
@@ -18,7 +18,9 @@ export class JobQueue {
   private inProgress: JobInQueue[] = []
   private lastUpdatedAt = new Date().toISOString()
 
-  constructor(private options: JobQueueOptions, private logger: Logger) {}
+  constructor(private options: JobQueueOptions, private logger: Logger) {
+    this.logger = logger.for(this)
+  }
 
   add(job: Job) {
     this.queue.push({ ...job, failureCount: 0 })
@@ -57,7 +59,7 @@ export class JobQueue {
       await job.execute()
       this.inProgress.splice(this.inProgress.indexOf(job), 1)
     } catch (error) {
-      this.logger.error(error)
+      this.logger.error(error, `Job "${job.name}" failed with:`)
       this.inProgress.splice(this.inProgress.indexOf(job), 1)
       this.queue.unshift({ ...job, failureCount: job.failureCount + 1 })
     } finally {

--- a/packages/backend/src/tools/Logger.ts
+++ b/packages/backend/src/tools/Logger.ts
@@ -30,7 +30,11 @@ export class Logger {
 
   // eslint-disable-next-line @typescript-eslint/ban-types
   for(object: {}) {
-    return this.configure({ service: object.constructor.name })
+    return this.configure({
+      service: this.options.service
+        ? `${this.options.service}.${object.constructor.name}`
+        : object.constructor.name,
+    })
   }
 
   error(error: unknown): void

--- a/packages/backend/src/tools/Logger.ts
+++ b/packages/backend/src/tools/Logger.ts
@@ -33,7 +33,11 @@ export class Logger {
     return this.configure({ service: object.constructor.name })
   }
 
-  error(error: unknown, annotation?: string) {
+  error(error: unknown): void
+  error(annotation: string, error: unknown): void
+  error(...args: [unknown] | [string, unknown]): void {
+    const [annotation, error] = args.length === 1 ? ['', args[0]] : args
+
     if (this.options.logLevel >= LogLevel.ERROR) {
       const message = [annotation, getErrorMessage(error)]
         .filter(Boolean)

--- a/packages/backend/src/tools/Logger.ts
+++ b/packages/backend/src/tools/Logger.ts
@@ -36,12 +36,13 @@ export class Logger {
   error(error: unknown): void
   error(annotation: string, error: unknown): void
   error(...args: [unknown] | [string, unknown]): void {
-    const [annotation, error] = args.length === 1 ? ['', args[0]] : args
-
     if (this.options.logLevel >= LogLevel.ERROR) {
+      const [annotation, error] = args.length === 1 ? ['', args[0]] : args
+
       const message = [annotation, getErrorMessage(error)]
         .filter(Boolean)
         .join(' ')
+
       this.print('error', { message })
     }
   }

--- a/packages/backend/src/tools/Logger.ts
+++ b/packages/backend/src/tools/Logger.ts
@@ -33,9 +33,9 @@ export class Logger {
     return this.configure({ service: object.constructor.name })
   }
 
-  error(error: unknown) {
+  error(error: unknown, annotation?: string) {
     if (this.options.logLevel >= LogLevel.ERROR) {
-      const message = getErrorMessage(error)
+      const message = [annotation, getErrorMessage(error)].join(' ')
       this.print('error', { message })
     }
   }

--- a/packages/backend/src/tools/Logger.ts
+++ b/packages/backend/src/tools/Logger.ts
@@ -35,7 +35,9 @@ export class Logger {
 
   error(error: unknown, annotation?: string) {
     if (this.options.logLevel >= LogLevel.ERROR) {
-      const message = [annotation, getErrorMessage(error)].join(' ')
+      const message = [annotation, getErrorMessage(error)]
+        .filter(Boolean)
+        .join(' ')
       this.print('error', { message })
     }
   }

--- a/packages/backend/src/tools/partition.ts
+++ b/packages/backend/src/tools/partition.ts
@@ -1,0 +1,27 @@
+/**
+ * Takes a predicate and a list of values and returns a a tuple (2-item array),
+ * with each item containing the subset of the list that matches the predicate
+ * and the complement of the predicate respectively
+ *
+ * @param predicate A predicate to determine which side the element belongs to.
+ * @param xs The list to partition
+ */
+export function partition<T, S extends T>(
+  xs: T[],
+  predicate: (val: T) => val is S
+): [S[], Exclude<T, S>[]]
+export function partition<T>(xs: T[], predicate: (x: T) => boolean): [T[], T[]]
+export function partition<T, S extends T>(
+  xs: T[],
+  predicate: ((val: T) => val is S) | ((val: T) => boolean)
+): [S[], Exclude<T, S>[]] {
+  const yays: S[] = []
+  const nays: Exclude<T, S>[] = []
+
+  for (const x of xs) {
+    if (predicate(x)) yays.push(x)
+    else nays.push(x as Exclude<T, S>)
+  }
+
+  return [yays, nays]
+}

--- a/packages/backend/test/core/SyncScheduler.test.ts
+++ b/packages/backend/test/core/SyncScheduler.test.ts
@@ -10,12 +10,13 @@ import { mock } from '../mock'
 
 describe(SyncScheduler.name, () => {
   it('syncs in batches', async () => {
+    const lastBlockNumberSynced = 1
     const {
       statusRepository,
       safeBlockService,
       dataSyncService,
       safeBlockListener,
-    } = setupMocks({ lastBlockNumberSynced: 1 })
+    } = setupMocks({ lastBlockNumberSynced })
 
     const batchSize = 3
     const syncScheduler = new SyncScheduler(
@@ -28,7 +29,7 @@ describe(SyncScheduler.name, () => {
 
     await syncScheduler.start()
 
-    expect(dataSyncService.revert).toHaveBeenCalledWith([])
+    expect(dataSyncService.revert).toHaveBeenCalledWith([lastBlockNumberSynced])
 
     safeBlockListener({ blockNumber: 10, timestamp: 0 })
 
@@ -59,7 +60,7 @@ describe(SyncScheduler.name, () => {
     )
 
     await syncScheduler.start()
-    expect(dataSyncService.revert).toHaveBeenCalledWith([])
+    expect(dataSyncService.revert).toHaveBeenCalledWith([0])
 
     safeBlockListener({ blockNumber: 8, timestamp: 0 })
     safeBlockListener({ blockNumber: 9, timestamp: 0 })

--- a/packages/backend/test/core/SyncScheduler.test.ts
+++ b/packages/backend/test/core/SyncScheduler.test.ts
@@ -94,7 +94,8 @@ describe(SyncScheduler.name, () => {
       mocks.statusRepository,
       mocks.safeBlockService,
       mocks.dataSyncService,
-      Logger.SILENT
+      Logger.SILENT,
+      6_000
     )
 
     await syncScheduler.start()

--- a/packages/backend/test/core/VerifierCollector.test.ts
+++ b/packages/backend/test/core/VerifierCollector.test.ts
@@ -1,0 +1,157 @@
+import { expect, mockFn } from 'earljs'
+
+import { VerifierCollector } from '../../src/core/VerifierCollector'
+import { EthereumAddress } from '../../src/model'
+import {
+  VerifierEventRecord,
+  VerifierEventRepository,
+} from '../../src/peripherals/database/VerifierEventRepository'
+import type { EthereumClient } from '../../src/peripherals/ethereum/EthereumClient'
+import {
+  BlockRange,
+  Filter,
+  FilterByBlockHash,
+} from '../../src/peripherals/ethereum/types'
+import { mock } from '../mock'
+
+describe(VerifierCollector.name, () => {
+  it('saves events to repository and returns verifier addresses', async () => {
+    const addOrUpdate = mockFn(async (_records: VerifierEventRecord[]) => {})
+    const getLogs = mockFn(
+      async (_filter: Filter | FilterByBlockHash) => testData().logs
+    )
+
+    const collector = new VerifierCollector(
+      mock<EthereumClient>({ getLogs }),
+      mock<VerifierEventRepository>({
+        addOrUpdate,
+        async getAll() {
+          return []
+        },
+      })
+    )
+
+    const blockRange: BlockRange = { from: 11813207, to: 13987296 }
+    const verifiers = await collector.collect(blockRange)
+
+    expect(getLogs).toHaveBeenCalledWith([
+      {
+        address: expect.stringMatching('0x'),
+        fromBlock: blockRange.from,
+        toBlock: blockRange.to,
+        topics: [
+          [
+            // ImplementationAdded
+            '0x723a7080d63c133cf338e44e00705cc1b7b2bde7e88d6218a8d62710a329ce1b',
+            // Upgraded
+            '0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b',
+          ],
+        ],
+      },
+    ])
+    expect(addOrUpdate).toHaveBeenCalledWith([
+      [
+        expect.objectWith({
+          name: 'ImplementationAdded',
+          blockNumber: 12004790,
+          implementation: '0xCC5B2c75cbbD281b2Fc4B58C7d5B080d023C92F2',
+          initializer:
+            '0x000000000000000000000000b1eda32c467569fbdc8c3e041c81825d76b32b84',
+        }),
+        expect.objectWith({
+          name: 'Upgraded',
+          blockNumber: 12004790,
+          implementation: '0xCC5B2c75cbbD281b2Fc4B58C7d5B080d023C92F2',
+        }),
+        expect.objectWith({
+          name: 'ImplementationAdded',
+          blockNumber: 12016212,
+          implementation: '0xCC5B2c75cbbD281b2Fc4B58C7d5B080d023C92F2',
+          initializer:
+            '0x000000000000000000000000894c4a12548fb18eaa48cf34f9cd874fc08b7fc3',
+        }),
+        expect.objectWith({
+          name: 'Upgraded',
+          blockNumber: 12016212,
+          implementation: '0xCC5B2c75cbbD281b2Fc4B58C7d5B080d023C92F2',
+        }),
+      ],
+    ])
+
+    expect(verifiers).toEqual([
+      EthereumAddress('0xB1EDA32c467569fbDC8C3E041C81825D76b32b84'),
+      EthereumAddress('0x894c4a12548FB18EaA48cF34f9Cd874Fc08b7FC3'),
+    ])
+  })
+})
+
+function testData() {
+  const logs = [
+    {
+      blockNumber: 12004790,
+      blockHash:
+        '0x50d4fde82ee2a75ad7983468fa326d8259d0aa20656e650027f6ad0e6d097f53',
+      transactionIndex: 180,
+      removed: false,
+      address: '0xC8c212f11f6ACca77A7afeB7282dEBa5530eb46C',
+      data: '0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000b1eda32c467569fbdc8c3e041c81825d76b32b84',
+      topics: [
+        '0x723a7080d63c133cf338e44e00705cc1b7b2bde7e88d6218a8d62710a329ce1b',
+        '0x000000000000000000000000cc5b2c75cbbd281b2fc4b58c7d5b080d023c92f2',
+      ],
+      transactionHash:
+        '0x0062d144cffa664f602e4e72441b283350c201b027420652d6ca15462594c83f',
+      logIndex: 188,
+    },
+    {
+      blockNumber: 12004790,
+      blockHash:
+        '0x50d4fde82ee2a75ad7983468fa326d8259d0aa20656e650027f6ad0e6d097f53',
+      transactionIndex: 181,
+      removed: false,
+      address: '0xC8c212f11f6ACca77A7afeB7282dEBa5530eb46C',
+      data: '0x',
+      topics: [
+        '0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b',
+        '0x000000000000000000000000cc5b2c75cbbd281b2fc4b58c7d5b080d023c92f2',
+      ],
+      transactionHash:
+        '0x714f3ed87ce0d04fa0244d8eb61d1069ffb4263bbd874d4d88b1fe8330ead3b3',
+      logIndex: 189,
+    },
+    {
+      blockNumber: 12016212,
+      blockHash:
+        '0x867fdd66b6dee527e1f5f6c9d742ca6776a8fd72a1919e019bff85b0a2c1005d',
+      transactionIndex: 118,
+      removed: false,
+      address: '0xC8c212f11f6ACca77A7afeB7282dEBa5530eb46C',
+      data: '0x000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000894c4a12548fb18eaa48cf34f9cd874fc08b7fc3',
+      topics: [
+        '0x723a7080d63c133cf338e44e00705cc1b7b2bde7e88d6218a8d62710a329ce1b',
+        '0x000000000000000000000000cc5b2c75cbbd281b2fc4b58c7d5b080d023c92f2',
+      ],
+      transactionHash:
+        '0x2f80fb929df9d9baa64b47d46e6e6a17e8350aeeb0e063e2f6765fb1b0eb129e',
+      logIndex: 243,
+    },
+    {
+      blockNumber: 12016212,
+      blockHash:
+        '0x867fdd66b6dee527e1f5f6c9d742ca6776a8fd72a1919e019bff85b0a2c1005d',
+      transactionIndex: 119,
+      removed: false,
+      address: '0xC8c212f11f6ACca77A7afeB7282dEBa5530eb46C',
+      data: '0x',
+      topics: [
+        '0xbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b',
+        '0x000000000000000000000000cc5b2c75cbbd281b2fc4b58c7d5b080d023c92f2',
+      ],
+      transactionHash:
+        '0x1eb3709cb9eb06ab8c9d3fc90ebbe8692100b9188c87619b883bc29865fd3dab',
+      logIndex: 244,
+    },
+  ]
+
+  return { logs }
+}

--- a/packages/backend/test/core/VerifierCollector.test.ts
+++ b/packages/backend/test/core/VerifierCollector.test.ts
@@ -16,7 +16,7 @@ import { mock } from '../mock'
 
 describe(VerifierCollector.name, () => {
   it('saves events to repository and returns verifier addresses', async () => {
-    const addOrUpdate = mockFn(async (_records: VerifierEventRecord[]) => {})
+    const add = mockFn(async (_records: VerifierEventRecord[]) => {})
     const getLogs = mockFn(
       async (_filter: Filter | FilterByBlockHash) => testData().logs
     )
@@ -24,7 +24,7 @@ describe(VerifierCollector.name, () => {
     const collector = new VerifierCollector(
       mock<EthereumClient>({ getLogs }),
       mock<VerifierEventRepository>({
-        addOrUpdate,
+        add,
         async getAll() {
           return []
         },
@@ -49,7 +49,7 @@ describe(VerifierCollector.name, () => {
         ],
       },
     ])
-    expect(addOrUpdate).toHaveBeenCalledWith([
+    expect(add).toHaveBeenCalledWith([
       [
         expect.objectWith({
           name: 'ImplementationAdded',

--- a/packages/backend/test/model/EthereumAddress.test.ts
+++ b/packages/backend/test/model/EthereumAddress.test.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai'
+
+import { EthereumAddress } from '../../src/model'
+
+describe('EthereumAddress', () => {
+  it('accepts lowercase addresses', () => {
+    const address = EthereumAddress(
+      '0xabcdabcd12345678abcdabcd12345678abcdabcd'
+    )
+    expect(address).to.be.a('string')
+  })
+
+  it('accepts addresses with checksum', () => {
+    const address = EthereumAddress(
+      '0xAbCdABCd12345678abcDabCd12345678ABcdaBcd'
+    )
+    expect(address).to.be.a('string')
+  })
+
+  it('checks the checksum', () => {
+    expect(() =>
+      EthereumAddress('0xAbCdABCd12345678abcDabCd12345678ABcdaBcD')
+    ).to.throw(TypeError, 'Invalid EthereumAddress')
+  })
+
+  it('does not accept invalid strings', () => {
+    expect(() => EthereumAddress('foo')).to.throw(
+      TypeError,
+      'Invalid EthereumAddress'
+    )
+  })
+
+  it('converts to a representation with a checksum', () => {
+    const address = EthereumAddress(
+      '0xabcdabcd12345678abcdabcd12345678abcdabcd'
+    )
+    expect(address).to.eq(
+      '0xAbCdABCd12345678abcDabCd12345678ABcdaBcd' as unknown as EthereumAddress
+    )
+  })
+
+  describe('isBefore', () => {
+    it('checks ordering', () => {
+      const a = EthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+      const b = EthereumAddress('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
+      expect(EthereumAddress.isBefore(a, b)).to.eq(true)
+      expect(EthereumAddress.isBefore(b, a)).to.eq(false)
+      expect(EthereumAddress.isBefore(a, a)).to.eq(false)
+    })
+
+    it('works for WETH & USDT', () => {
+      const weth = EthereumAddress('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2')
+      const usdt = EthereumAddress('0xdAC17F958D2ee523a2206206994597C13D831ec7')
+      expect(EthereumAddress.isBefore(weth, usdt)).to.eq(true)
+      expect(EthereumAddress.isBefore(usdt, weth)).to.eq(false)
+    })
+  })
+
+  it('ZERO is the zero address', () => {
+    expect(EthereumAddress.ZERO).to.eq(
+      ('0x' + '0'.repeat(40)) as unknown as EthereumAddress
+    )
+  })
+})

--- a/packages/backend/test/model/EthereumAddress.test.ts
+++ b/packages/backend/test/model/EthereumAddress.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai'
+import { expect } from 'earljs'
 
 import { EthereumAddress } from '../../src/model'
 
@@ -7,24 +7,24 @@ describe('EthereumAddress', () => {
     const address = EthereumAddress(
       '0xabcdabcd12345678abcdabcd12345678abcdabcd'
     )
-    expect(address).to.be.a('string')
+    expect(address).toBeA(String)
   })
 
   it('accepts addresses with checksum', () => {
     const address = EthereumAddress(
       '0xAbCdABCd12345678abcDabCd12345678ABcdaBcd'
     )
-    expect(address).to.be.a('string')
+    expect(address).toBeA(String)
   })
 
   it('checks the checksum', () => {
     expect(() =>
       EthereumAddress('0xAbCdABCd12345678abcDabCd12345678ABcdaBcD')
-    ).to.throw(TypeError, 'Invalid EthereumAddress')
+    ).toThrow(TypeError, 'Invalid EthereumAddress')
   })
 
   it('does not accept invalid strings', () => {
-    expect(() => EthereumAddress('foo')).to.throw(
+    expect(() => EthereumAddress('foo')).toThrow(
       TypeError,
       'Invalid EthereumAddress'
     )
@@ -34,7 +34,7 @@ describe('EthereumAddress', () => {
     const address = EthereumAddress(
       '0xabcdabcd12345678abcdabcd12345678abcdabcd'
     )
-    expect(address).to.eq(
+    expect(address).toEqual(
       '0xAbCdABCd12345678abcDabCd12345678ABcdaBcd' as unknown as EthereumAddress
     )
   })
@@ -43,21 +43,21 @@ describe('EthereumAddress', () => {
     it('checks ordering', () => {
       const a = EthereumAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
       const b = EthereumAddress('0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb')
-      expect(EthereumAddress.isBefore(a, b)).to.eq(true)
-      expect(EthereumAddress.isBefore(b, a)).to.eq(false)
-      expect(EthereumAddress.isBefore(a, a)).to.eq(false)
+      expect(EthereumAddress.isBefore(a, b)).toEqual(true)
+      expect(EthereumAddress.isBefore(b, a)).toEqual(false)
+      expect(EthereumAddress.isBefore(a, a)).toEqual(false)
     })
 
     it('works for WETH & USDT', () => {
       const weth = EthereumAddress('0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2')
       const usdt = EthereumAddress('0xdAC17F958D2ee523a2206206994597C13D831ec7')
-      expect(EthereumAddress.isBefore(weth, usdt)).to.eq(true)
-      expect(EthereumAddress.isBefore(usdt, weth)).to.eq(false)
+      expect(EthereumAddress.isBefore(weth, usdt)).toEqual(true)
+      expect(EthereumAddress.isBefore(usdt, weth)).toEqual(false)
     })
   })
 
   it('ZERO is the zero address', () => {
-    expect(EthereumAddress.ZERO).to.eq(
+    expect(EthereumAddress.ZERO).toEqual(
       ('0x' + '0'.repeat(40)) as unknown as EthereumAddress
     )
   })

--- a/packages/backend/test/peripherals/database/DatabaseService.test.ts
+++ b/packages/backend/test/peripherals/database/DatabaseService.test.ts
@@ -12,7 +12,6 @@ describe('DatabaseService', () => {
 
     await databaseService.migrateToLatest()
     await databaseService.rollbackAll()
-
     const result = await knex.raw(
       'SELECT table_name FROM information_schema.tables WHERE table_schema = current_schema()'
     )

--- a/packages/backend/test/peripherals/database/VerifierEventRepository.test.ts
+++ b/packages/backend/test/peripherals/database/VerifierEventRepository.test.ts
@@ -1,0 +1,81 @@
+import { expect } from 'chai'
+
+import {
+  VerifierEventRecord,
+  VerifierEventRepository,
+} from '../../../src/peripherals/database/VerifierEventRepository'
+import { Logger } from '../../../src/tools/Logger'
+import { setupDatabaseTestSuite } from './setup'
+
+describe(VerifierEventRepository.name, () => {
+  const { knex } = setupDatabaseTestSuite()
+  const repository = new VerifierEventRepository(knex, Logger.SILENT)
+
+  afterEach(() => repository.deleteAll())
+
+  it('adds single record and queries it', async () => {
+    const record: VerifierEventRecord = {
+      name: 'ImplementationAdded',
+      implementation: '0x0000000000000000000000000000000000000000',
+      initializer: '0x0000000000000000000000000000000000000000',
+      blockNumber: 1,
+    }
+
+    await repository.addOrUpdate([record])
+
+    const actual = await repository.getAll()
+
+    expect(actual[0]).to.include(record)
+  })
+
+  it('adds multiple records and queries them', async () => {
+    const records: VerifierEventRecord[] = [
+      {
+        name: 'ImplementationAdded',
+        implementation: '0x0000000000000000000000000000000000000000',
+        initializer: '0x00000000000000000000000000000000000000000',
+        blockNumber: 1,
+      },
+      {
+        name: 'Upgraded',
+        implementation: '0x0000000000000000000000000000000000000001',
+        blockNumber: 2,
+      },
+      {
+        name: 'ImplementationAdded',
+        implementation: '0x0000000000000000000000000000000000000001',
+        initializer: '0x0000000000000000000000000000000000000002',
+        blockNumber: 2,
+      },
+    ]
+
+    await repository.addOrUpdate(records)
+    const actual = await repository.getAll()
+
+    // @todo earl's `id: expect.any(Number)`
+    expect(actual[0]).to.include(records[0])
+    expect(actual[1]).to.include(records[1])
+    expect(actual[2]).to.include(records[2])
+  })
+
+  it('deletes all records', async () => {
+    await repository.addOrUpdate([
+      {
+        name: 'ImplementationAdded',
+        initializer: '0x0000000000000000000000000000000000000001',
+        implementation: '0x0000000000000000000000000000000000000002',
+        blockNumber: 1,
+      },
+      {
+        name: 'Upgraded',
+        implementation: '0x0000000000000000000000000000000000000002',
+        blockNumber: 2,
+      },
+    ])
+
+    await repository.deleteAll()
+
+    const actual = await repository.getAll()
+    expect(actual).to.deep.eq([])
+  })
+})

--- a/packages/backend/test/peripherals/database/VerifierEventRepository.test.ts
+++ b/packages/backend/test/peripherals/database/VerifierEventRepository.test.ts
@@ -60,42 +60,6 @@ describe(VerifierEventRepository.name, () => {
     expect(actual).toEqual(records.map((r) => ({ ...r, id: expect.a(Number) })))
   })
 
-  it('gets all after block number', async () => {
-    await repository.add([
-      {
-        name: 'Upgraded',
-        implementation: '0x0000000000000000000000000000000000000001',
-        blockNumber: 1,
-      },
-      {
-        name: 'Upgraded',
-        implementation: '0x0000000000000000000000000000000000000002',
-        blockNumber: 2,
-      },
-      {
-        name: 'Upgraded',
-        implementation: '0x0000000000000000000000000000000000000003',
-        blockNumber: 3,
-      },
-    ])
-
-    const actual = await repository.getAllAfter(1)
-    expect(actual).toEqual([
-      {
-        name: 'Upgraded',
-        implementation: '0x0000000000000000000000000000000000000002',
-        blockNumber: 2,
-        id: expect.a(Number),
-      },
-      {
-        name: 'Upgraded',
-        implementation: '0x0000000000000000000000000000000000000003',
-        blockNumber: 3,
-        id: expect.a(Number),
-      },
-    ])
-  })
-
   it('deletes all records', async () => {
     await repository.add([
       {

--- a/packages/backend/test/peripherals/database/VerifierEventRepository.test.ts
+++ b/packages/backend/test/peripherals/database/VerifierEventRepository.test.ts
@@ -21,7 +21,7 @@ describe(VerifierEventRepository.name, () => {
       blockNumber: 1,
     }
 
-    await repository.addOrUpdate([record])
+    await repository.add([record])
 
     const actual = await repository.getAll()
 
@@ -49,7 +49,7 @@ describe(VerifierEventRepository.name, () => {
       },
     ]
 
-    await repository.addOrUpdate(records)
+    await repository.add(records)
     const actual = await repository.getAll()
 
     // @todo earl's `id: expect.any(Number)`
@@ -59,7 +59,7 @@ describe(VerifierEventRepository.name, () => {
   })
 
   it('deletes all records', async () => {
-    await repository.addOrUpdate([
+    await repository.add([
       {
         name: 'ImplementationAdded',
         initializer: '0x0000000000000000000000000000000000000001',

--- a/packages/backend/test/peripherals/database/VerifierEventRepository.test.ts
+++ b/packages/backend/test/peripherals/database/VerifierEventRepository.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai'
+import { expect } from 'earljs'
 
 import {
   VerifierEventRecord,
@@ -25,7 +25,12 @@ describe(VerifierEventRepository.name, () => {
 
     const actual = await repository.getAll()
 
-    expect(actual[0]).to.include(record)
+    expect(actual).toEqual([
+      {
+        ...record,
+        id: expect.a(Number),
+      },
+    ])
   })
 
   it('adds multiple records and queries them', async () => {
@@ -52,10 +57,43 @@ describe(VerifierEventRepository.name, () => {
     await repository.add(records)
     const actual = await repository.getAll()
 
-    // @todo earl's `id: expect.any(Number)`
-    expect(actual[0]).to.include(records[0])
-    expect(actual[1]).to.include(records[1])
-    expect(actual[2]).to.include(records[2])
+    expect(actual).toEqual(records.map((r) => ({ ...r, id: expect.a(Number) })))
+  })
+
+  it('gets all after block number', async () => {
+    await repository.add([
+      {
+        name: 'Upgraded',
+        implementation: '0x0000000000000000000000000000000000000001',
+        blockNumber: 1,
+      },
+      {
+        name: 'Upgraded',
+        implementation: '0x0000000000000000000000000000000000000002',
+        blockNumber: 2,
+      },
+      {
+        name: 'Upgraded',
+        implementation: '0x0000000000000000000000000000000000000003',
+        blockNumber: 3,
+      },
+    ])
+
+    const actual = await repository.getAllAfter(1)
+    expect(actual).toEqual([
+      {
+        name: 'Upgraded',
+        implementation: '0x0000000000000000000000000000000000000002',
+        blockNumber: 2,
+        id: expect.a(Number),
+      },
+      {
+        name: 'Upgraded',
+        implementation: '0x0000000000000000000000000000000000000003',
+        blockNumber: 3,
+        id: expect.a(Number),
+      },
+    ])
   })
 
   it('deletes all records', async () => {
@@ -76,6 +114,44 @@ describe(VerifierEventRepository.name, () => {
     await repository.deleteAll()
 
     const actual = await repository.getAll()
-    expect(actual).to.deep.eq([])
+    expect(actual).toEqual([])
+  })
+
+  it('deletes all records after a block number', async () => {
+    await repository.add([
+      {
+        name: 'Upgraded',
+        implementation: '0x0000000000000000000000000000000000000001',
+        blockNumber: 1,
+      },
+      {
+        name: 'Upgraded',
+        implementation: '0x0000000000000000000000000000000000000002',
+        blockNumber: 2,
+      },
+      {
+        name: 'Upgraded',
+        implementation: '0x0000000000000000000000000000000000000003',
+        blockNumber: 3,
+      },
+    ])
+
+    await repository.deleteAllAfter(2)
+
+    const actual = await repository.getAll()
+    expect(actual).toEqual([
+      {
+        name: 'Upgraded',
+        implementation: '0x0000000000000000000000000000000000000001',
+        blockNumber: 1,
+        id: expect.a(Number),
+      },
+      {
+        name: 'Upgraded',
+        implementation: '0x0000000000000000000000000000000000000002',
+        blockNumber: 2,
+        id: expect.a(Number),
+      },
+    ])
   })
 })

--- a/packages/backend/test/tools/partition.test.ts
+++ b/packages/backend/test/tools/partition.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai'
+import { expect } from 'earljs'
 
 import { partition } from '../../src/tools/partition'
 
@@ -9,8 +9,8 @@ describe(partition.name, () => {
       (x) => x % 2 === 0
     )
 
-    expect(evens).to.deep.eq([0, 2, 4, 6, 8])
-    expect(odds).to.deep.eq([1, 3, 5, 7, 9])
+    expect(evens).toEqual([0, 2, 4, 6, 8])
+    expect(odds).toEqual([1, 3, 5, 7, 9])
   })
 
   it('partitions an array of union types given type predicate', () => {
@@ -21,7 +21,7 @@ describe(partition.name, () => {
 
     const [as, bs] = partition(xs, (x): x is A => 'a' in x)
 
-    expect(as.map((a) => a.a)).to.deep.eq([1, 3])
-    expect(bs.map((b) => b.b)).to.deep.eq([2, 4])
+    expect(as.map((a) => a.a)).toEqual([1, 3])
+    expect(bs.map((b) => b.b)).toEqual([2, 4])
   })
 })

--- a/packages/backend/test/tools/partition.test.ts
+++ b/packages/backend/test/tools/partition.test.ts
@@ -1,0 +1,27 @@
+import { expect } from 'chai'
+
+import { partition } from '../../src/tools/partition'
+
+describe(partition.name, () => {
+  it('partitions an array of numbers given a predicate', () => {
+    const [evens, odds] = partition(
+      Array.from(Array(10).keys()),
+      (x) => x % 2 === 0
+    )
+
+    expect(evens).to.deep.eq([0, 2, 4, 6, 8])
+    expect(odds).to.deep.eq([1, 3, 5, 7, 9])
+  })
+
+  it('partitions an array of union types given type predicate', () => {
+    type A = { a: number }
+    type B = { b: number }
+    type AB = A | B
+    const xs: AB[] = [{ a: 1 }, { b: 2 }, { a: 3 }, { b: 4 }]
+
+    const [as, bs] = partition(xs, (x): x is A => 'a' in x)
+
+    expect(as.map((a) => a.a)).to.deep.eq([1, 3])
+    expect(bs.map((b) => b.b)).to.deep.eq([2, 4])
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2072,6 +2072,17 @@ each-props@^1.3.2:
     is-plain-object "^2.0.1"
     object.defaults "^1.1.0"
 
+earljs@^0.1.12:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/earljs/-/earljs-0.1.12.tgz#92437d349dfc580e49adc24c76ecdad0b222d7b0"
+  integrity sha512-qTuYVJgbGdb1syLeQ/mD/SIm914TGI9kxzVrXQ3a03lzFQsKP202tqsdBFqU9d+J8k7fM41eglmLvzKGt0FJhw==
+  dependencies:
+    debug "^4.1.1"
+    jest-snapshot "^26.6.2"
+    lodash "^4.17.15"
+    pretty-format "^26.6.2"
+    ts-essentials "^6.0.5"
+
 earljs@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/earljs/-/earljs-0.2.0.tgz#bb36d1088e9bbd637a05b137e83260773ea1516a"
@@ -4032,7 +4043,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.21, lodash@^4.17.4:
+lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION

**What's changed?**

- Added _VerifierCollector_ to store _ImplementationAdded_ and _Upgraded_ events in the database.
- Changed _SyncScheduler's_ `BATCH_SIZE` to 10000 — having 500 there caused very slow updates. How high can we get without causing problems? @sz-piotr 
- Added `003_verifier_events` db migration.

---

I've put all Upgraded and ImplementationAdded events in the same table for easier inspection.

![image](https://user-images.githubusercontent.com/15332326/149159443-8f584ae8-9ddc-46d7-ace5-ca4c15dab0b0.png)

Didn't use Postgres native enums, but we should be able to change this pretty easily with `table.enum('name', { enumName: 'VerifierEventName', useNative: true }`. I'm not sure if we want to.