### PR TITLE
Display coverage chart in PR comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,4 @@
 comment: # https://docs.codecov.io/docs/pull-request-comments
-  layout: "files"
   behavior: default
   require_changes: false
   require_base: false


### PR DESCRIPTION
This PR resets Codecov's `comment.layout` setting to its default to show a more detailed Pull Request comment.