### PR TITLE
Stop running `yarn test` on CI, as `yarn coverage` fails when test fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
       - run: yarn build
       - run: yarn lint
       - run: yarn typecheck
-      - run: yarn test
+      - name: "test and upload coverage"
+        run: yarn coverage
         env:
           TEST_DB_URL: postgresql://postgres:postgres@localhost:5432/postgres
-      - run: yarn coverage
       - uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
This PR fixes two issues we currently have on CI.

1. First `yarn test` check was redundant, as tests are ran by `yarn coverage` and any non-zero exit code from tests will also fail `yarn coverage` step.
2. `yarn coverage` step didn't run database tests, as `TEST_DB_URL` env var was only given to `yarn test` step.