### PR TITLE
Unify request validation

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -36,7 +36,8 @@
     "koa-static": "^5.0.0",
     "lodash": "^4.17.21",
     "pg": "^8.7.1",
-    "source-map-support": "^0.5.21"
+    "source-map-support": "^0.5.21",
+    "zod": "^3.11.6"
   },
   "devDependencies": {
     "@sinonjs/fake-timers": "^7.1.2",

--- a/packages/backend/src/api/routers/FrontendRouter.ts
+++ b/packages/backend/src/api/routers/FrontendRouter.ts
@@ -2,31 +2,8 @@ import { PedersenHash } from '@explorer/crypto'
 import Router from '@koa/router'
 import { z } from 'zod'
 
-import {
-  brandedString,
-  stringToPositiveInt,
-  withRequestDataParsing,
-} from '../../tools/RequestDataParsing'
 import { FrontendController } from '../controllers/FrontendController'
-
-const GetStateChangesParser = z.object({
-  query: z.object({
-    page: stringToPositiveInt('1'),
-    perPage: stringToPositiveInt('10'),
-  }),
-})
-
-const GetStateChangeDetailsParser = z.object({
-  params: z.object({
-    hash: brandedString(PedersenHash),
-  }),
-})
-
-const GetPositionDetailsParser = z.object({
-  params: z.object({
-    positionId: brandedString(BigInt),
-  }),
-})
+import { brandedString, stringToPositiveInt, withTypedContext } from './types'
 
 export function createFrontendRouter(frontendController: FrontendController) {
   const router = new Router()
@@ -37,9 +14,15 @@ export function createFrontendRouter(frontendController: FrontendController) {
 
   router.get(
     '/state-updates',
-    withRequestDataParsing(
-      GetStateChangesParser,
-      async (ctx, { query: { page, perPage } }) => {
+    withTypedContext(
+      z.object({
+        query: z.object({
+          page: stringToPositiveInt('1'),
+          perPage: stringToPositiveInt('10'),
+        }),
+      }),
+      async (ctx) => {
+        const { page, perPage } = ctx.query
         ctx.body = await frontendController.getStateChangesPage(page, perPage)
       }
     )
@@ -47,9 +30,14 @@ export function createFrontendRouter(frontendController: FrontendController) {
 
   router.get(
     '/state-updates/:hash',
-    withRequestDataParsing(
-      GetStateChangeDetailsParser,
-      async (ctx, { params: { hash } }) => {
+    withTypedContext(
+      z.object({
+        params: z.object({
+          hash: brandedString(PedersenHash),
+        }),
+      }),
+      async (ctx) => {
+        const { hash } = ctx.params
         ctx.body = await frontendController.getStateChangeDetailsPage(hash)
       }
     )
@@ -57,9 +45,14 @@ export function createFrontendRouter(frontendController: FrontendController) {
 
   router.get(
     '/positions/:positionId',
-    withRequestDataParsing(
-      GetPositionDetailsParser,
-      async (ctx, { params: { positionId } }) => {
+    withTypedContext(
+      z.object({
+        params: z.object({
+          positionId: brandedString(BigInt),
+        }),
+      }),
+      async (ctx) => {
+        const { positionId } = ctx.params
         ctx.body = await frontendController.getPositionDetailsPage(positionId)
       }
     )

--- a/packages/backend/src/api/routers/FrontendRouter.ts
+++ b/packages/backend/src/api/routers/FrontendRouter.ts
@@ -2,39 +2,30 @@ import { PedersenHash } from '@explorer/crypto'
 import Router from '@koa/router'
 import { z } from 'zod'
 
+import {
+  brandedString,
+  stringToPositiveInt,
+  withRequestDataParsing,
+} from '../../tools/RequestDataParsing'
 import { FrontendController } from '../controllers/FrontendController'
 
-const stringToPositiveInt = (def: string) =>
-  z.preprocess(
-    (s) => parseInt(z.string().parse(s || def), 10),
-    z.number().positive()
-  )
-
-function brandedString<T>(brandedType: (value: string) => T) {
-  return z
-    .string()
-    .refine((v) => {
-      try {
-        brandedType(v)
-        return true
-      } catch {
-        return false
-      }
-    })
-    .transform(brandedType)
-}
-
-const StateUpdatesQuery = z.object({
-  page: stringToPositiveInt('1'),
-  perPage: stringToPositiveInt('10'),
+const GetStateChangesParser = z.object({
+  query: z.object({
+    page: stringToPositiveInt('1'),
+    perPage: stringToPositiveInt('10'),
+  }),
 })
 
-const StateChangeDetailsQuery = z.object({
-  hash: brandedString(PedersenHash),
+const GetStateChangeDetailsParser = z.object({
+  params: z.object({
+    hash: brandedString(PedersenHash),
+  }),
 })
 
-const PositionQuery = z.object({
-  positionId: brandedString(BigInt),
+const GetPositionDetailsParser = z.object({
+  params: z.object({
+    positionId: brandedString(BigInt),
+  }),
 })
 
 export function createFrontendRouter(frontendController: FrontendController) {
@@ -44,44 +35,35 @@ export function createFrontendRouter(frontendController: FrontendController) {
     ctx.body = await frontendController.getHomePage()
   })
 
-  router.get('/state-updates', async (ctx) => {
-    const parseResult = StateUpdatesQuery.safeParse(ctx.query)
-    if (!parseResult.success) {
-      ctx.status = 400
-      ctx.body = { issues: parseResult.error.issues }
-      return
-    }
-    const {
-      data: { page, perPage },
-    } = parseResult
-    ctx.body = await frontendController.getStateChangesPage(page, perPage)
-  })
+  router.get(
+    '/state-updates',
+    withRequestDataParsing(
+      GetStateChangesParser,
+      async (ctx, { query: { page, perPage } }) => {
+        ctx.body = await frontendController.getStateChangesPage(page, perPage)
+      }
+    )
+  )
 
-  router.get('/state-updates/:hash', async (ctx) => {
-    const parseResult = StateChangeDetailsQuery.safeParse(ctx.params)
-    if (!parseResult.success) {
-      ctx.status = 400
-      ctx.body = { issues: parseResult.error.issues }
-      return
-    }
-    const {
-      data: { hash },
-    } = parseResult
-    ctx.body = await frontendController.getStateChangeDetailsPage(hash)
-  })
+  router.get(
+    '/state-updates/:hash',
+    withRequestDataParsing(
+      GetStateChangeDetailsParser,
+      async (ctx, { params: { hash } }) => {
+        ctx.body = await frontendController.getStateChangeDetailsPage(hash)
+      }
+    )
+  )
 
-  router.get('/positions/:positionId', async (ctx) => {
-    const parseResult = PositionQuery.safeParse(ctx.params)
-    if (!parseResult.success) {
-      ctx.status = 400
-      ctx.body = { issues: parseResult.error.issues }
-      return
-    }
-    const {
-      data: { positionId },
-    } = parseResult
-    ctx.body = await frontendController.getPositionDetailsPage(positionId)
-  })
+  router.get(
+    '/positions/:positionId',
+    withRequestDataParsing(
+      GetPositionDetailsParser,
+      async (ctx, { params: { positionId } }) => {
+        ctx.body = await frontendController.getPositionDetailsPage(positionId)
+      }
+    )
+  )
 
   return router
 }

--- a/packages/backend/src/api/routers/types.ts
+++ b/packages/backend/src/api/routers/types.ts
@@ -3,8 +3,8 @@ import { z } from 'zod'
 
 export function stringToPositiveInt(def: string) {
   return z.preprocess(
-    (s) => parseInt(z.string().parse(s || def), 10),
-    z.number().positive()
+    (s) => Number(z.string().parse(s ?? def)),
+    z.number().int().positive()
   )
 }
 

--- a/packages/backend/src/api/routers/types.ts
+++ b/packages/backend/src/api/routers/types.ts
@@ -24,7 +24,7 @@ export function brandedString<T>(brandedType: (value: string) => T) {
 
 export type TypedContext<T> = Omit<
   Application.ParameterizedContext,
-  'body' | 'params' | 'query'
+  'params' | 'query'
 > &
   T
 
@@ -34,7 +34,6 @@ export function withTypedContext<T extends z.AnyZodObject>(
 ) {
   return async (ctx: Application.ParameterizedContext) => {
     const parseResult = parser.safeParse({
-      body: ctx.body,
       params: ctx.params,
       query: ctx.query,
     })
@@ -43,7 +42,6 @@ export function withTypedContext<T extends z.AnyZodObject>(
       ctx.body = { issues: parseResult.error.issues }
       return
     }
-    ctx.body = parseResult.data.body
     ctx.params = parseResult.data.params
     ctx.query = parseResult.data.query
     await handler(ctx)

--- a/packages/backend/src/tools/RequestDataParsing.ts
+++ b/packages/backend/src/tools/RequestDataParsing.ts
@@ -1,0 +1,45 @@
+import Application from 'koa'
+import { z } from 'zod'
+
+export function stringToPositiveInt(def: string) {
+  return z.preprocess(
+    (s) => parseInt(z.string().parse(s || def), 10),
+    z.number().positive()
+  )
+}
+
+export function brandedString<T>(brandedType: (value: string) => T) {
+  return z
+    .string()
+    .refine((v) => {
+      try {
+        brandedType(v)
+        return true
+      } catch {
+        return false
+      }
+    })
+    .transform(brandedType)
+}
+
+export function withRequestDataParsing<T extends z.AnyZodObject>(
+  parser: T,
+  handler: (
+    ctx: Application.ParameterizedContext,
+    data: z.infer<T>
+  ) => Promise<void>
+) {
+  return async (_ctx: Application.ParameterizedContext) => {
+    const parseResult = parser.safeParse({
+      body: _ctx.body,
+      params: _ctx.params,
+      query: _ctx.query,
+    })
+    if (!parseResult.success) {
+      _ctx.status = 400
+      _ctx.body = { issues: parseResult.error.issues }
+      return
+    }
+    await handler(_ctx, parseResult.data)
+  }
+}

--- a/packages/backend/test/api/routers/FrontendRouter.test.ts
+++ b/packages/backend/test/api/routers/FrontendRouter.test.ts
@@ -39,7 +39,7 @@ describe('FrontendRouter', () => {
     })
 
     it('does not allow invalid input', async () => {
-      await server.get('/state-updates?page=foo&perPage=bar').expect(500)
+      await server.get('/state-updates?page=foo&perPage=bar').expect(400)
     })
   })
 
@@ -61,7 +61,7 @@ describe('FrontendRouter', () => {
     })
 
     it('does not allow invalid input', async () => {
-      await server.get('/state-updates/foo').expect(500)
+      await server.get('/state-updates/foo').expect(400)
     })
   })
 
@@ -78,7 +78,7 @@ describe('FrontendRouter', () => {
     })
 
     it('does not allow invalid input', async () => {
-      await server.get('/positions/foo').expect(500)
+      await server.get('/positions/foo').expect(400)
     })
   })
 })

--- a/packages/backend/test/api/routers/types.test.ts
+++ b/packages/backend/test/api/routers/types.test.ts
@@ -1,0 +1,25 @@
+import { expect } from 'earljs'
+
+import { stringToPositiveInt } from '../../../src/api/routers/types'
+
+describe(stringToPositiveInt.name, () => {
+  const parser = stringToPositiveInt('10')
+
+  describe('parses correct input', () => {
+    const inputs = [undefined, null, '1']
+
+    inputs.forEach((input) => {
+      it(`${input}`, () =>
+        expect(parser.safeParse(input).success).toEqual(true))
+    })
+  })
+
+  describe('parses incorrect input', () => {
+    const inputs = ['foo', '123foo', '', '1.2']
+
+    inputs.forEach((input) => {
+      it(`${input}`, () =>
+        expect(parser.safeParse(input).success).toEqual(false))
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -7196,3 +7196,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.11.6:
+  version "3.11.6"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.11.6.tgz#e43a5e0c213ae2e02aefe7cb2b1a6fa3d7f1f483"
+  integrity sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg==


### PR DESCRIPTION
To figure out:
1. Typing of `withRequestDataParsing` to enforce input shape to have `body`, `params` and `query` keys,
2. Where to put helpers.