### PR TITLE
Improve navigation between projects

### DIFF
--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "declaration": false
+    "declaration": false,
+    "declarationMap": false
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react",
-    "declaration": true
+    "declaration": true,
+    "declarationMap": true // to fix code navigation issues: https://github.com/microsoft/vscode/issues/73201
   }
 }


### PR DESCRIPTION
This should allow clicking on symbols imported from a different, internal package and navigating to the sourcecode rather than to `.d.ts` file. 

Goes best with additional vscode settings:
```
// https://twitter.com/krzKaczor/status/1120631267781951488
  "editor.gotoLocation.multipleDefinitions": "goto",
  "editor.gotoLocation.multipleImplementations": "goto",
  "editor.gotoLocation.multipleTypeDefinitions": "goto",
  "editor.gotoLocation.multipleDeclarations": "goto",
  "editor.gotoLocation.multipleReferences": "goto"
```