### PR TITLE
Unify repository code

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -56,3 +56,13 @@ You can configure the behavior of the app with the following environment variabl
 - `LOG_LEVEL` - Integer specifying the log level (`0 | 1 | 2 | 3`). See `src/tools/Logger.ts`
 - `PORT` - The port on which the application exposes the api
 - `MAX_BLOCK_NUMBER` - Integer specifying the maximum block number that is going to be stored - all blocks created later in time will be skipped (used in environments with limited database space e.g. heroku review apps)
+
+## Repository naming convention
+
+- `add(T): number` - adds a new record and returns it's id
+- `addMany(T[]): number[]` - adds many new records and returns their ids
+- `getAll(): T[]` - returns an array of all records
+- `getByKey(K): T[]` - returns an array of all matching records
+- `findByKey(K): T?` - returns a single matching record or undefined
+- `deleteAll(): number` - removes all records and returns the number of removed records
+- `deleteByKey(K): number` - removes all matching records and returns the number of removed records

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -49,7 +49,6 @@
     "@sinonjs/fake-timers": "^7.1.2",
     "@types/object-hash": "^2.2.1",
     "@types/supertest": "^2.0.11",
-    "conditional-type-checks": "^1.0.5",
     "supertest": "^6.1.6",
     "wait-for-expect": "^3.0.2"
   }

--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -139,6 +139,7 @@ export class Application {
 
     const positionController = new PositionController(
       stateUpdateRepository,
+      positionRepository,
       userRegistrationEventRepository,
       forcedTransactionsRepository
     )

--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -158,6 +158,7 @@ export class Application {
     )
     const searchController = new SearchController(
       stateUpdateRepository,
+      positionRepository,
       userRegistrationEventRepository
     )
     const apiServer = new ApiServer(config.port, logger, {

--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -154,6 +154,7 @@ export class Application {
     )
     const stateUpdateController = new StateUpdateController(
       stateUpdateRepository,
+      positionRepository,
       forcedTransactionsRepository
     )
     const searchController = new SearchController(

--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -25,6 +25,7 @@ import { FactToPageRepository } from './peripherals/database/FactToPageRepositor
 import { ForcedTransactionsRepository } from './peripherals/database/ForcedTransactionsRepository'
 import { KeyValueStore } from './peripherals/database/KeyValueStore'
 import { PageRepository } from './peripherals/database/PageRepository'
+import { PositionRepository } from './peripherals/database/PositionRepository'
 import { RollupStateRepository } from './peripherals/database/RollupStateRepository'
 import { StateTransitionFactRepository } from './peripherals/database/StateTransitionFactsRepository'
 import { StateUpdateRepository } from './peripherals/database/StateUpdateRepository'
@@ -60,6 +61,7 @@ export class Application {
     const blockRepository = new BlockRepository(knex, logger)
     const rollupStateRepository = new RollupStateRepository(knex, logger)
     const stateUpdateRepository = new StateUpdateRepository(knex, logger)
+    const positionRepository = new PositionRepository(knex, logger)
     const userRegistrationEventRepository = new UserRegistrationEventRepository(
       knex,
       logger
@@ -142,6 +144,7 @@ export class Application {
     )
     const homeController = new HomeController(
       stateUpdateRepository,
+      positionRepository,
       forcedTransactionsRepository
     )
     const forcedTransactionController = new ForcedTransactionController(

--- a/packages/backend/src/api/controllers/HomeController.ts
+++ b/packages/backend/src/api/controllers/HomeController.ts
@@ -2,6 +2,7 @@ import { renderHomePage } from '@explorer/frontend'
 import { EthereumAddress } from '@explorer/types'
 
 import { ForcedTransactionsRepository } from '../../peripherals/database/ForcedTransactionsRepository'
+import { PositionRepository } from '../../peripherals/database/PositionRepository'
 import { StateUpdateRepository } from '../../peripherals/database/StateUpdateRepository'
 import { ControllerResult } from './ControllerResult'
 import { toForcedTransactionEntry } from './utils/toForcedTransactionEntry'
@@ -10,6 +11,7 @@ import { toStateUpdateEntry } from './utils/toStateUpdateEntry'
 export class HomeController {
   constructor(
     private stateUpdateRepository: StateUpdateRepository,
+    private positionRepository: PositionRepository,
     private forcedTransactionsRepository: ForcedTransactionsRepository
   ) {}
 
@@ -24,7 +26,7 @@ export class HomeController {
         this.stateUpdateRepository.getStateUpdateList({ offset, limit }),
         this.forcedTransactionsRepository.getLatest({ limit, offset }),
         this.stateUpdateRepository.countStateUpdates(),
-        this.stateUpdateRepository.countPositions(),
+        this.positionRepository.count(),
       ])
 
     const content = renderHomePage({

--- a/packages/backend/src/api/controllers/HomeController.ts
+++ b/packages/backend/src/api/controllers/HomeController.ts
@@ -23,9 +23,9 @@ export class HomeController {
 
     const [stateUpdates, transactions, totalUpdates, totalPositions] =
       await Promise.all([
-        this.stateUpdateRepository.getStateUpdateList({ offset, limit }),
+        this.stateUpdateRepository.getPaginated({ offset, limit }),
         this.forcedTransactionsRepository.getLatest({ limit, offset }),
-        this.stateUpdateRepository.countStateUpdates(),
+        this.stateUpdateRepository.count(),
         this.positionRepository.count(),
       ])
 

--- a/packages/backend/src/api/controllers/PositionController.ts
+++ b/packages/backend/src/api/controllers/PositionController.ts
@@ -90,7 +90,7 @@ export class PositionController {
   ): Promise<ControllerResult> {
     const [history, update, transactions] = await Promise.all([
       this.positionRepository.getHistoryById(positionId),
-      this.stateUpdateRepository.getStateUpdateById(stateUpdateId),
+      this.stateUpdateRepository.findByIdWithPositions(stateUpdateId),
       this.forcedTransactionsRepository.getIncludedInStateUpdate(stateUpdateId),
     ])
     const updateIndex = history.findIndex(

--- a/packages/backend/src/api/controllers/PositionController.ts
+++ b/packages/backend/src/api/controllers/PositionController.ts
@@ -5,6 +5,7 @@ import {
 import { EthereumAddress } from '@explorer/types'
 
 import { ForcedTransactionsRepository } from '../../peripherals/database/ForcedTransactionsRepository'
+import { PositionRepository } from '../../peripherals/database/PositionRepository'
 import { StateUpdateRepository } from '../../peripherals/database/StateUpdateRepository'
 import { UserRegistrationEventRepository } from '../../peripherals/database/UserRegistrationEventRepository'
 import { ControllerResult } from './ControllerResult'
@@ -15,6 +16,7 @@ import { toPositionAssetEntries } from './utils/toPositionAssetEntries'
 export class PositionController {
   constructor(
     private stateUpdateRepository: StateUpdateRepository,
+    private positionRepository: PositionRepository,
     private userRegistrationEventRepository: UserRegistrationEventRepository,
     private forcedTransactionsRepository: ForcedTransactionsRepository
   ) {}
@@ -24,7 +26,7 @@ export class PositionController {
     account: EthereumAddress | undefined
   ): Promise<ControllerResult> {
     const [history, transactions] = await Promise.all([
-      this.stateUpdateRepository.getPositionHistoryById(positionId),
+      this.positionRepository.getHistoryById(positionId),
       this.forcedTransactionsRepository.getAffectingPosition(positionId),
     ])
 
@@ -87,7 +89,7 @@ export class PositionController {
     account: EthereumAddress | undefined
   ): Promise<ControllerResult> {
     const [history, update, transactions] = await Promise.all([
-      this.stateUpdateRepository.getPositionHistoryById(positionId),
+      this.positionRepository.getHistoryById(positionId),
       this.stateUpdateRepository.getStateUpdateById(stateUpdateId),
       this.forcedTransactionsRepository.getIncludedInStateUpdate(stateUpdateId),
     ])

--- a/packages/backend/src/api/controllers/SearchController.ts
+++ b/packages/backend/src/api/controllers/SearchController.ts
@@ -61,7 +61,7 @@ export class SearchController {
     hash: PedersenHash
   ): Promise<ControllerResult | undefined> {
     const stateUpdateId =
-      await this.stateUpdateRepository.getStateUpdateIdByRootHash(hash)
+      await this.stateUpdateRepository.findIdByRootHash(hash)
     if (stateUpdateId === undefined) {
       return
     }

--- a/packages/backend/src/api/controllers/SearchController.ts
+++ b/packages/backend/src/api/controllers/SearchController.ts
@@ -1,5 +1,6 @@
 import { EthereumAddress, PedersenHash, StarkKey } from '@explorer/types'
 
+import { PositionRepository } from '../../peripherals/database/PositionRepository'
 import { StateUpdateRepository } from '../../peripherals/database/StateUpdateRepository'
 import { UserRegistrationEventRepository } from '../../peripherals/database/UserRegistrationEventRepository'
 import { ControllerResult } from './ControllerResult'
@@ -7,6 +8,7 @@ import { ControllerResult } from './ControllerResult'
 export class SearchController {
   constructor(
     private stateUpdateRepository: StateUpdateRepository,
+    private positionRepository: PositionRepository,
     private userRegistrationEventRepository: UserRegistrationEventRepository
   ) {}
 
@@ -46,10 +48,9 @@ export class SearchController {
       return
     }
 
-    const positionId =
-      await this.stateUpdateRepository.getPositionIdByPublicKey(
-        userRegistrationEvent.starkKey
-      )
+    const positionId = await this.positionRepository.findIdByPublicKey(
+      userRegistrationEvent.starkKey
+    )
     if (positionId === undefined) {
       return
     }
@@ -60,8 +61,9 @@ export class SearchController {
   private async searchForRootHash(
     hash: PedersenHash
   ): Promise<ControllerResult | undefined> {
-    const stateUpdateId =
-      await this.stateUpdateRepository.findIdByRootHash(hash)
+    const stateUpdateId = await this.stateUpdateRepository.findIdByRootHash(
+      hash
+    )
     if (stateUpdateId === undefined) {
       return
     }
@@ -78,10 +80,9 @@ export class SearchController {
       return
     }
 
-    const positionId =
-      await this.stateUpdateRepository.getPositionIdByPublicKey(
-        userRegistrationEvent.starkKey
-      )
+    const positionId = await this.positionRepository.findIdByPublicKey(
+      userRegistrationEvent.starkKey
+    )
     if (positionId === undefined) {
       return
     }

--- a/packages/backend/src/api/controllers/StateUpdateController.ts
+++ b/packages/backend/src/api/controllers/StateUpdateController.ts
@@ -5,10 +5,8 @@ import {
 import { EthereumAddress } from '@explorer/types'
 
 import { ForcedTransactionsRepository } from '../../peripherals/database/ForcedTransactionsRepository'
-import {
-  PositionWithPricesRecord,
-  StateUpdateRepository,
-} from '../../peripherals/database/StateUpdateRepository'
+import { PositionWithPricesRecord } from '../../peripherals/database/PositionRepository'
+import { StateUpdateRepository } from '../../peripherals/database/StateUpdateRepository'
 import { ControllerResult } from './ControllerResult'
 import { countUpdatedAssets } from './utils/countUpdatedAssets'
 import { toForcedTransactionEntry } from './utils/toForcedTransactionEntry'

--- a/packages/backend/src/core/MemoryHashEventCollector.ts
+++ b/packages/backend/src/core/MemoryHashEventCollector.ts
@@ -32,7 +32,7 @@ export class MemoryHashEventCollector {
     )
     const hashEvents = events.flat()
 
-    await this.factToPageRepository.add(
+    await this.factToPageRepository.addMany(
       hashEvents.flatMap((event) =>
         event.pagesHashes.map((pageHash, index) => ({
           index,

--- a/packages/backend/src/core/StateTransitionFactCollector.ts
+++ b/packages/backend/src/core/StateTransitionFactCollector.ts
@@ -24,12 +24,14 @@ export class StateTransitionFactCollector {
     private readonly stateTransitionFactRepository: StateTransitionFactRepository
   ) {}
 
-  async collect(blockRange: BlockRange): Promise<StateTransitionFactRecord[]> {
+  async collect(
+    blockRange: BlockRange
+  ): Promise<Omit<StateTransitionFactRecord, 'id'>[]> {
     const logs = await this.ethereumClient.getLogsInRange(blockRange, {
       address: PERPETUAL_ADDRESS,
       topics: [LOG_STATE_TRANSITION_FACT],
     })
-    const records = logs.map((log): StateTransitionFactRecord => {
+    const records = logs.map((log): Omit<StateTransitionFactRecord, 'id'> => {
       const event = PERPETUAL_ABI.parseLog(log)
       return {
         blockNumber: log.blockNumber,
@@ -37,11 +39,11 @@ export class StateTransitionFactCollector {
       }
     })
 
-    await this.stateTransitionFactRepository.add(records)
+    await this.stateTransitionFactRepository.addMany(records)
     return records
   }
 
   async discardAfter(lastToKeep: BlockNumber) {
-    await this.stateTransitionFactRepository.deleteAllAfter(lastToKeep)
+    await this.stateTransitionFactRepository.deleteAfter(lastToKeep)
   }
 }

--- a/packages/backend/src/core/StateUpdateCollector.ts
+++ b/packages/backend/src/core/StateUpdateCollector.ts
@@ -42,7 +42,7 @@ export class StateUpdateCollector {
       return
     }
 
-    const dbTransitions = await this.pageRepository.getAllForFacts(
+    const dbTransitions = await this.pageRepository.getByFactHashes(
       stateTransitionFacts.map((f) => f.hash)
     )
     const stateTransitions = dbTransitions.map((x, i) => ({

--- a/packages/backend/src/core/StateUpdateCollector.ts
+++ b/packages/backend/src/core/StateUpdateCollector.ts
@@ -149,7 +149,7 @@ export class StateUpdateCollector {
   }
 
   private async readLastUpdate() {
-    const lastUpdate = await this.stateUpdateRepository.getLast()
+    const lastUpdate = await this.stateUpdateRepository.findLast()
     if (lastUpdate) {
       return { oldHash: lastUpdate.rootHash, id: lastUpdate.id }
     }

--- a/packages/backend/src/core/StateUpdateCollector.ts
+++ b/packages/backend/src/core/StateUpdateCollector.ts
@@ -37,7 +37,7 @@ export class StateUpdateCollector {
     private rollupState?: RollupState
   ) {}
 
-  async save(stateTransitionFacts: StateTransitionFactRecord[]) {
+  async save(stateTransitionFacts: Omit<StateTransitionFactRecord, 'id'>[]) {
     if (stateTransitionFacts.length === 0) {
       return
     }

--- a/packages/backend/src/core/StateUpdateCollector.ts
+++ b/packages/backend/src/core/StateUpdateCollector.ts
@@ -4,12 +4,10 @@ import { Hash256, PedersenHash, Timestamp } from '@explorer/types'
 
 import { ForcedTransactionsRepository } from '../peripherals/database/ForcedTransactionsRepository'
 import { PageRepository } from '../peripherals/database/PageRepository'
+import { PositionRecord } from '../peripherals/database/PositionRepository'
 import { RollupStateRepository } from '../peripherals/database/RollupStateRepository'
 import { StateTransitionFactRecord } from '../peripherals/database/StateTransitionFactsRepository'
-import {
-  PositionRecord,
-  StateUpdateRepository,
-} from '../peripherals/database/StateUpdateRepository'
+import { StateUpdateRepository } from '../peripherals/database/StateUpdateRepository'
 import { EthereumClient } from '../peripherals/ethereum/EthereumClient'
 import { BlockNumber } from '../peripherals/ethereum/types'
 

--- a/packages/backend/src/core/StateUpdateCollector.ts
+++ b/packages/backend/src/core/StateUpdateCollector.ts
@@ -142,7 +142,7 @@ export class StateUpdateCollector {
   }
 
   async discardAfter(blockNumber: BlockNumber) {
-    await this.stateUpdateRepository.deleteAllAfter(blockNumber)
+    await this.stateUpdateRepository.deleteAfter(blockNumber)
     await this.forcedTransactionsRepository.discardAfter(blockNumber)
   }
 

--- a/packages/backend/src/core/sync/BlockDownloader.ts
+++ b/packages/backend/src/core/sync/BlockDownloader.ts
@@ -129,7 +129,7 @@ export class BlockDownloader {
         number: block.number,
         hash: Hash256(block.hash),
       }))
-      await this.blockRepository.deleteAllAfter(records[0].number - 1)
+      await this.blockRepository.deleteAfter(records[0].number - 1)
       await this.blockRepository.addMany(records)
       this.lastKnown = blockNumber
       return ['reorg', records] as const

--- a/packages/backend/src/core/sync/BlockDownloader.ts
+++ b/packages/backend/src/core/sync/BlockDownloader.ts
@@ -37,7 +37,7 @@ export class BlockDownloader {
 
   async start() {
     this.started = true
-    this.lastKnown = (await this.blockRepository.getLast())?.number ?? 0
+    this.lastKnown = (await this.blockRepository.findLast())?.number ?? 0
     this.queueTip = await this.ethereumClient.getBlockNumber()
 
     const queueStart = Math.max(
@@ -70,7 +70,7 @@ export class BlockDownloader {
   }
 
   async getKnownBlocks(from: number) {
-    const lastKnown = await this.blockRepository.getLast()
+    const lastKnown = await this.blockRepository.findLast()
     if (!lastKnown) {
       return []
     }
@@ -111,7 +111,7 @@ export class BlockDownloader {
         number: block.number,
         hash: Hash256(block.hash),
       }
-      await this.blockRepository.add([record])
+      await this.blockRepository.addMany([record])
       this.lastKnown = blockNumber
       return ['newBlock', record] as const
     } else {
@@ -130,14 +130,14 @@ export class BlockDownloader {
         hash: Hash256(block.hash),
       }))
       await this.blockRepository.deleteAllAfter(records[0].number - 1)
-      await this.blockRepository.add(records)
+      await this.blockRepository.addMany(records)
       this.lastKnown = blockNumber
       return ['reorg', records] as const
     }
   }
 
   private async getKnownBlock(blockNumber: number): Promise<BlockRecord> {
-    const known = await this.blockRepository.getByNumber(blockNumber)
+    const known = await this.blockRepository.findByNumber(blockNumber)
     if (known) {
       return known
     }
@@ -146,7 +146,7 @@ export class BlockDownloader {
       number: downloaded.number,
       hash: Hash256(downloaded.hash),
     }
-    await this.blockRepository.add([record])
+    await this.blockRepository.addMany([record])
     return record
   }
 }

--- a/packages/backend/src/peripherals/database/BaseRepository.ts
+++ b/packages/backend/src/peripherals/database/BaseRepository.ts
@@ -2,8 +2,12 @@ import { Knex } from 'knex'
 
 import { Logger } from '../../tools/Logger'
 
-interface AddMethod<T> {
-  (record: T): Promise<number>
+interface AnyMethod<A extends unknown[], R> {
+  (...args: A): Promise<R>
+}
+
+interface AddMethod<T, R> {
+  (record: T): Promise<R>
 }
 
 interface AddManyMethod<T> {
@@ -23,11 +27,26 @@ interface DeleteMethod<A extends unknown[]> {
 }
 
 export class BaseRepository {
-  constructor(protected knex: Knex, protected logger: Logger) {
+  constructor(
+    protected readonly knex: Knex,
+    protected readonly logger: Logger
+  ) {
     this.logger = logger.for(this)
   }
 
-  wrapAdd<T>(method: AddMethod<T>): AddMethod<T> {
+  protected wrapAny<A extends unknown[], R>(
+    method: AnyMethod<A, R>
+  ): AnyMethod<A, R> {
+    return async (...args: A) => {
+      const result = await method.call(this, ...args)
+      this.logger.debug({ method: method.name })
+      return result
+    }
+  }
+
+  protected wrapAdd<T, R extends number | string>(
+    method: AddMethod<T, R>
+  ): AddMethod<T, R> {
     return async (value: T) => {
       const id = await method.call(this, value)
       this.logger.debug({ method: method.name, id: id })
@@ -35,7 +54,7 @@ export class BaseRepository {
     }
   }
 
-  wrapAddMany<T>(method: AddManyMethod<T>): AddManyMethod<T> {
+  protected wrapAddMany<T>(method: AddManyMethod<T>): AddManyMethod<T> {
     return async (records: T[]) => {
       if (records.length === 0) {
         this.logger.debug({ method: method.name, count: 0 })
@@ -47,7 +66,9 @@ export class BaseRepository {
     }
   }
 
-  wrapGet<A extends unknown[], T>(method: GetMethod<A, T>): GetMethod<A, T> {
+  protected wrapGet<A extends unknown[], T>(
+    method: GetMethod<A, T>
+  ): GetMethod<A, T> {
     return async (...args: A) => {
       const records = await method.call(this, ...args)
       this.logger.debug({ method: method.name, count: records.length })
@@ -55,7 +76,9 @@ export class BaseRepository {
     }
   }
 
-  wrapFind<A extends unknown[], T>(method: FindMethod<A, T>): FindMethod<A, T> {
+  protected wrapFind<A extends unknown[], T>(
+    method: FindMethod<A, T>
+  ): FindMethod<A, T> {
     return async (...args: A) => {
       const record = await method.call(this, ...args)
       this.logger.debug({ method: method.name, count: record ? 1 : 0 })
@@ -63,7 +86,9 @@ export class BaseRepository {
     }
   }
 
-  wrapDelete<A extends unknown[]>(method: DeleteMethod<A>): DeleteMethod<A> {
+  protected wrapDelete<A extends unknown[]>(
+    method: DeleteMethod<A>
+  ): DeleteMethod<A> {
     return async (...args: A) => {
       const count = await method.call(this, ...args)
       this.logger.debug({ method: method.name, count })

--- a/packages/backend/src/peripherals/database/BaseRepository.ts
+++ b/packages/backend/src/peripherals/database/BaseRepository.ts
@@ -1,0 +1,73 @@
+import { Knex } from 'knex'
+
+import { Logger } from '../../tools/Logger'
+
+interface AddMethod<T> {
+  (record: T): Promise<number>
+}
+
+interface AddManyMethod<T> {
+  (records: T[]): Promise<number[]>
+}
+
+interface GetMethod<A extends unknown[], T> {
+  (...args: A): Promise<T[]>
+}
+
+interface FindMethod<A extends unknown[], T> {
+  (...args: A): Promise<T | undefined>
+}
+
+interface DeleteMethod<A extends unknown[]> {
+  (...args: A): Promise<number>
+}
+
+export class BaseRepository {
+  constructor(protected knex: Knex, protected logger: Logger) {
+    this.logger = logger.for(this)
+  }
+
+  wrapAdd<T>(method: AddMethod<T>): AddMethod<T> {
+    return async (value: T) => {
+      const id = await method.call(this, value)
+      this.logger.debug({ method: method.name, id: id })
+      return id
+    }
+  }
+
+  wrapAddMany<T>(method: AddManyMethod<T>): AddManyMethod<T> {
+    return async (records: T[]) => {
+      if (records.length === 0) {
+        this.logger.debug({ method: method.name, count: 0 })
+        return []
+      }
+      const ids = await method.call(this, records)
+      this.logger.debug({ method: method.name, count: ids.length })
+      return ids
+    }
+  }
+
+  wrapGet<A extends unknown[], T>(method: GetMethod<A, T>): GetMethod<A, T> {
+    return async (...args: A) => {
+      const records = await method.call(this, ...args)
+      this.logger.debug({ method: method.name, count: records.length })
+      return records
+    }
+  }
+
+  wrapFind<A extends unknown[], T>(method: FindMethod<A, T>): FindMethod<A, T> {
+    return async (...args: A) => {
+      const record = await method.call(this, ...args)
+      this.logger.debug({ method: method.name, count: record ? 1 : 0 })
+      return record
+    }
+  }
+
+  wrapDelete<A extends unknown[]>(method: DeleteMethod<A>): DeleteMethod<A> {
+    return async (...args: A) => {
+      const count = await method.call(this, ...args)
+      this.logger.debug({ method: method.name, count })
+      return count
+    }
+  }
+}

--- a/packages/backend/src/peripherals/database/BlockRepository.ts
+++ b/packages/backend/src/peripherals/database/BlockRepository.ts
@@ -3,33 +3,35 @@ import { Knex } from 'knex'
 import { BlockRow } from 'knex/types/tables'
 
 import { Logger } from '../../tools/Logger'
-import { Repository } from './types'
+import { BaseRepository } from './BaseRepository'
 
 export interface BlockRecord {
   number: number
   hash: Hash256
 }
 
-export class BlockRepository implements Repository<BlockRecord> {
-  constructor(private knex: Knex, private logger: Logger) {
-    this.logger = logger.for(this)
+export class BlockRepository extends BaseRepository {
+  constructor(knex: Knex, logger: Logger) {
+    super(knex, logger)
+
+    this.addMany = this.wrapAddMany(this.addMany)
+    this.getAll = this.wrapGet(this.getAll)
+    this.getAllInRange = this.wrapGet(this.getAllInRange)
+    this.findLast = this.wrapFind(this.findLast)
+    this.findByNumber = this.wrapFind(this.findByNumber)
+    this.findByHash = this.wrapFind(this.findByHash)
+    this.deleteAll = this.wrapDelete(this.deleteAll)
+    this.deleteAllAfter = this.wrapDelete(this.deleteAllAfter)
   }
 
-  async add(records: BlockRecord[]) {
-    if (records.length === 0) {
-      this.logger.debug({ method: 'add', rows: 0 })
-      return
-    }
-
+  async addMany(records: BlockRecord[]) {
     const rows: BlockRow[] = records.map(toRow)
-    await this.knex('blocks').insert(rows)
-
-    this.logger.debug({ method: 'add', rows: rows.length })
+    const numbers = await this.knex('blocks').insert(rows).returning('number')
+    return numbers
   }
 
   async getAll(): Promise<BlockRecord[]> {
     const rows = await this.knex('blocks').select('*')
-    this.logger.debug({ method: 'getAll', rows: rows.length })
     return rows.map(toRecord)
   }
 
@@ -39,57 +41,30 @@ export class BlockRepository implements Repository<BlockRecord> {
       .where('number', '>=', from)
       .andWhere('number', '<=', to)
       .orderBy('number')
-    this.logger.debug({ method: 'getAllUntil', rows: rows.length })
     return rows.map(toRecord)
   }
 
-  async getLast(): Promise<BlockRecord | undefined> {
+  async findLast(): Promise<BlockRecord | undefined> {
     const row = await this.knex('blocks').orderBy('number', 'desc').first()
-
-    this.logger.debug({
-      method: 'getLast',
-      number: row?.number ?? null,
-      hash: row?.hash ?? null,
-    })
-
     return row && toRecord(row)
   }
 
-  async getByNumber(number: number): Promise<BlockRecord | undefined> {
+  async findByNumber(number: number): Promise<BlockRecord | undefined> {
     const row = await this.knex('blocks').where('number', number).first()
-
-    this.logger.debug({
-      method: 'getByNumber',
-      number,
-      hash: row?.hash ?? null,
-    })
-
     return row && toRecord(row)
   }
 
-  async getByHash(hash: Hash256): Promise<BlockRecord | undefined> {
+  async findByHash(hash: Hash256): Promise<BlockRecord | undefined> {
     const row = await this.knex('blocks').where('hash', hash.toString()).first()
-
-    this.logger.debug({
-      method: 'getByHash',
-      hash: hash.toString(),
-      number: row?.number ?? null,
-    })
-
     return row && toRecord(row)
   }
 
   async deleteAll() {
-    await this.knex('blocks').delete()
-    this.logger.debug({ method: 'deleteAll' })
+    return await this.knex('blocks').delete()
   }
 
   async deleteAllAfter(blockNumber: number) {
-    const rowsCount = await this.knex('blocks')
-      .where('number', '>', blockNumber)
-      .delete()
-
-    this.logger.debug({ method: 'deleteAllAfter', rows: rowsCount })
+    return await this.knex('blocks').where('number', '>', blockNumber).delete()
   }
 }
 

--- a/packages/backend/src/peripherals/database/BlockRepository.ts
+++ b/packages/backend/src/peripherals/database/BlockRepository.ts
@@ -21,7 +21,7 @@ export class BlockRepository extends BaseRepository {
     this.findByNumber = this.wrapFind(this.findByNumber)
     this.findByHash = this.wrapFind(this.findByHash)
     this.deleteAll = this.wrapDelete(this.deleteAll)
-    this.deleteAllAfter = this.wrapDelete(this.deleteAllAfter)
+    this.deleteAfter = this.wrapDelete(this.deleteAfter)
   }
 
   async addMany(records: BlockRecord[]) {
@@ -63,7 +63,7 @@ export class BlockRepository extends BaseRepository {
     return await this.knex('blocks').delete()
   }
 
-  async deleteAllAfter(blockNumber: number) {
+  async deleteAfter(blockNumber: number) {
     return await this.knex('blocks').where('number', '>', blockNumber).delete()
   }
 }

--- a/packages/backend/src/peripherals/database/FactToPageRepository.ts
+++ b/packages/backend/src/peripherals/database/FactToPageRepository.ts
@@ -3,56 +3,50 @@ import { Knex } from 'knex'
 import { FactToPageRow } from 'knex/types/tables'
 
 import { Logger } from '../../tools/Logger'
-import { Repository } from './types'
+import { BaseRepository } from './BaseRepository'
 
 export interface FactToPageRecord {
-  id?: number
+  id: number
   blockNumber: number
   factHash: Hash256
   pageHash: Hash256
   index: number
 }
 
-export class FactToPageRepository implements Repository<FactToPageRecord> {
-  constructor(private knex: Knex, private logger: Logger) {
-    this.logger = logger.for(this)
+export class FactToPageRepository extends BaseRepository {
+  constructor(knex: Knex, logger: Logger) {
+    super(knex, logger)
+    this.addMany = this.wrapAddMany(this.addMany)
+    this.getAll = this.wrapGet(this.getAll)
+    this.deleteAll = this.wrapDelete(this.deleteAll)
+    this.deleteAllAfter = this.wrapDelete(this.deleteAllAfter)
   }
 
-  async add(records: FactToPageRecord[]) {
-    if (records.length === 0) {
-      this.logger.debug({ method: 'add', rows: 0 })
-      return
-    }
-
-    const rows: FactToPageRow[] = records.map(toRow)
-    await this.knex('fact_to_pages').insert(rows)
-
-    this.logger.debug({ method: 'add', rows: rows.length })
+  async addMany(records: Omit<FactToPageRecord, 'id'>[]) {
+    const rows = records.map(toRow)
+    return await this.knex('fact_to_pages').insert(rows).returning('id')
   }
 
   async getAll() {
     const rows = await this.knex('fact_to_pages').select('*')
-    this.logger.debug({ method: 'getAll', rows: rows.length })
     return rows.map(toRecord)
   }
 
   async deleteAll() {
-    await this.knex('fact_to_pages').delete()
-    this.logger.debug({ method: 'deleteAll' })
+    return await this.knex('fact_to_pages').delete()
   }
 
   async deleteAllAfter(blockNumber: number) {
-    const rowsCount = await this.knex('fact_to_pages')
+    return await this.knex('fact_to_pages')
       .where('block_number', '>', blockNumber)
       .delete()
-
-    this.logger.debug({ method: 'deleteAllAfter', rows: rowsCount })
   }
 }
 
-function toRow(record: FactToPageRecord): FactToPageRow {
+function toRow(
+  record: Omit<FactToPageRecord, 'id'>
+): Omit<FactToPageRow, 'id'> {
   return {
-    id: record.id,
     block_number: record.blockNumber,
     fact_hash: record.factHash.toString(),
     page_hash: record.pageHash.toString(),

--- a/packages/backend/src/peripherals/database/PositionRepository.ts
+++ b/packages/backend/src/peripherals/database/PositionRepository.ts
@@ -21,8 +21,9 @@ export interface PositionWithPricesRecord extends PositionRecord {
 export class PositionRepository extends BaseRepository {
   constructor(knex: Knex, logger: Logger) {
     super(knex, logger)
-    this.count = this.wrapAny(this.count)
     this.getHistoryById = this.wrapGet(this.getHistoryById)
+    this.findIdByPublicKey = this.wrapFind(this.findIdByPublicKey)
+    this.count = this.wrapAny(this.count)
   }
 
   async getHistoryById(positionId: bigint) {
@@ -48,6 +49,13 @@ export class PositionRepository extends BaseRepository {
         timestamp: Timestamp(r.timestamp),
       }
     })
+  }
+
+  async findIdByPublicKey(publicKey: StarkKey): Promise<bigint | undefined> {
+    const row = await this.knex('positions')
+      .where('public_key', publicKey.toString())
+      .first('position_id')
+    return row?.position_id
   }
 
   async count() {

--- a/packages/backend/src/peripherals/database/PositionRepository.ts
+++ b/packages/backend/src/peripherals/database/PositionRepository.ts
@@ -23,6 +23,7 @@ export class PositionRepository extends BaseRepository {
     super(knex, logger)
     this.getHistoryById = this.wrapGet(this.getHistoryById)
     this.findIdByPublicKey = this.wrapFind(this.findIdByPublicKey)
+    this.getPreviousStates = this.wrapGet(this.getPreviousStates)
     this.count = this.wrapAny(this.count)
   }
 
@@ -56,6 +57,35 @@ export class PositionRepository extends BaseRepository {
       .where('public_key', publicKey.toString())
       .first('position_id')
     return row?.position_id
+  }
+
+  async getPreviousStates(positionIds: bigint[], stateUpdateId: number) {
+    const rows = await this.knex
+      .select('p1.*', this.knex.raw('array_agg(row_to_json(prices)) as prices'))
+      .from('positions as p1')
+      .innerJoin(
+        this.knex
+          .select(
+            'position_id',
+            this.knex.raw('max(state_update_id) as prev_state_update_id')
+          )
+          .from('positions')
+          .as('p2')
+          .whereIn('position_id', positionIds)
+          .andWhere('state_update_id', '<', stateUpdateId)
+          .groupBy('position_id'),
+        function () {
+          return this.on('p1.position_id', '=', 'p2.position_id').andOn(
+            'p1.state_update_id',
+            '=',
+            'p2.prev_state_update_id'
+          )
+        }
+      )
+      .innerJoin('prices', 'prices.state_update_id', 'p1.state_update_id')
+      .groupBy('p1.state_update_id', 'p1.position_id')
+
+    return rows.map(toPositionWithPricesRecord)
   }
 
   async count() {

--- a/packages/backend/src/peripherals/database/PositionRepository.ts
+++ b/packages/backend/src/peripherals/database/PositionRepository.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex'
+
+import { Logger } from '../../tools/Logger'
+import { BaseRepository } from './BaseRepository'
+
+export class PositionRepository extends BaseRepository {
+  constructor(knex: Knex, logger: Logger) {
+    super(knex, logger)
+    this.count = this.wrapAny(this.count)
+  }
+
+  async count() {
+    const [{ count }] = await this.knex('positions').countDistinct({
+      count: 'position_id',
+    })
+    return count ? BigInt(count) : 0n
+  }
+}

--- a/packages/backend/src/peripherals/database/PositionRepository.ts
+++ b/packages/backend/src/peripherals/database/PositionRepository.ts
@@ -1,12 +1,53 @@
+import { AssetBalance } from '@explorer/encoding'
+import { AssetId, StarkKey, Timestamp } from '@explorer/types'
 import { Knex } from 'knex'
+import { AssetBalanceJson, PositionRow, PriceRow } from 'knex/types/tables'
 
 import { Logger } from '../../tools/Logger'
 import { BaseRepository } from './BaseRepository'
+
+export interface PositionRecord {
+  positionId: bigint
+  publicKey: StarkKey
+  collateralBalance: bigint
+  balances: readonly AssetBalance[]
+}
+
+export interface PositionWithPricesRecord extends PositionRecord {
+  stateUpdateId: number
+  prices: { assetId: AssetId; price: bigint }[]
+}
 
 export class PositionRepository extends BaseRepository {
   constructor(knex: Knex, logger: Logger) {
     super(knex, logger)
     this.count = this.wrapAny(this.count)
+    this.getHistoryById = this.wrapGet(this.getHistoryById)
+  }
+
+  async getHistoryById(positionId: bigint) {
+    const rows = await this.knex('positions')
+      .where('position_id', positionId)
+      .orderBy('positions.state_update_id', 'desc')
+      .join('prices', 'prices.state_update_id', 'positions.state_update_id')
+      .join('state_updates', 'state_updates.id', 'positions.state_update_id')
+      .groupBy(
+        'positions.position_id',
+        'positions.state_update_id',
+        'state_updates.timestamp'
+      )
+      .select(
+        'positions.*',
+        'state_updates.timestamp as timestamp',
+        this.knex.raw('array_agg(row_to_json(prices)) as prices')
+      )
+
+    return rows.map((r) => {
+      return {
+        ...toPositionWithPricesRecord(r),
+        timestamp: Timestamp(r.timestamp),
+      }
+    })
   }
 
   async count() {
@@ -14,5 +55,55 @@ export class PositionRepository extends BaseRepository {
       count: 'position_id',
     })
     return count ? BigInt(count) : 0n
+  }
+}
+
+export function toPositionRecord(
+  row: PositionRow
+): PositionRecord & { stateUpdateId: number } {
+  return {
+    stateUpdateId: row.state_update_id,
+    positionId: BigInt(row.position_id),
+    publicKey: StarkKey(row.public_key),
+    collateralBalance: BigInt(row.collateral_balance),
+    balances: (typeof row.balances === 'string'
+      ? (JSON.parse(row.balances) as AssetBalanceJson[])
+      : row.balances
+    ).map((x) => ({
+      assetId: AssetId(x.asset_id),
+      balance: BigInt(x.balance),
+    })),
+  }
+}
+
+export function toPositionWithPricesRecord(
+  row: PositionRow & { prices: PriceRow[] }
+): PositionWithPricesRecord {
+  return {
+    ...toPositionRecord(row),
+    prices: row.prices.filter(Boolean).map((p) => ({
+      assetId: AssetId(p.asset_id),
+      price: BigInt(p.price),
+    })),
+  }
+}
+
+export function toPositionRow(
+  record: PositionRecord,
+  stateUpdateId: number
+): PositionRow {
+  const balances = record.balances.map(
+    (x): AssetBalanceJson => ({
+      asset_id: x.assetId.toString(),
+      balance: x.balance.toString(),
+    })
+  )
+
+  return {
+    state_update_id: stateUpdateId,
+    position_id: record.positionId,
+    public_key: record.publicKey.toString(),
+    collateral_balance: record.collateralBalance,
+    balances: JSON.stringify(balances),
   }
 }

--- a/packages/backend/src/peripherals/database/StateUpdateRepository.ts
+++ b/packages/backend/src/peripherals/database/StateUpdateRepository.ts
@@ -36,6 +36,7 @@ export class StateUpdateRepository extends BaseRepository {
     super(knex, logger)
     this.add = this.wrapAdd(this.add)
     this.findLast = this.wrapFind(this.findLast)
+    this.findIdByRootHash = this.wrapFind(this.findIdByRootHash)
   }
 
   async add({ stateUpdate, positions, prices }: StateUpdateBundle) {
@@ -62,14 +63,11 @@ export class StateUpdateRepository extends BaseRepository {
     return row && toStateUpdateRecord(row)
   }
 
-  async getStateUpdateIdByRootHash(
-    hash: PedersenHash
-  ): Promise<number | undefined> {
-    const rows = await this.knex('state_updates')
+  async findIdByRootHash(hash: PedersenHash): Promise<number | undefined> {
+    const row = await this.knex('state_updates')
       .where('root_hash', hash.toString())
-      .select('state_updates.id as id')
-
-    return rows[0]?.id
+      .first('id')
+    return row?.id
   }
 
   async getPositionIdByPublicKey(

--- a/packages/backend/src/peripherals/database/StateUpdateRepository.ts
+++ b/packages/backend/src/peripherals/database/StateUpdateRepository.ts
@@ -1,11 +1,5 @@
 import { OraclePrice } from '@explorer/encoding'
-import {
-  AssetId,
-  Hash256,
-  PedersenHash,
-  StarkKey,
-  Timestamp,
-} from '@explorer/types'
+import { AssetId, Hash256, PedersenHash, Timestamp } from '@explorer/types'
 import { Knex } from 'knex'
 import { PriceRow, StateUpdateRow } from 'knex/types/tables'
 
@@ -68,16 +62,6 @@ export class StateUpdateRepository extends BaseRepository {
       .where('root_hash', hash.toString())
       .first('id')
     return row?.id
-  }
-
-  async getPositionIdByPublicKey(
-    publicKey: StarkKey
-  ): Promise<bigint | undefined> {
-    const rows = await this.knex('positions')
-      .where('public_key', publicKey.toString())
-      .select('positions.position_id as id')
-
-    return rows[0]?.id
   }
 
   async getAll() {

--- a/packages/backend/src/peripherals/database/StateUpdateRepository.ts
+++ b/packages/backend/src/peripherals/database/StateUpdateRepository.ts
@@ -250,13 +250,6 @@ export class StateUpdateRepository {
     const [{ count }] = await this.knex('state_updates').count({ count: '*' })
     return count ? BigInt(count) : 0n
   }
-
-  async countPositions() {
-    const [{ count }] = await this.knex('positions').countDistinct({
-      count: 'position_id',
-    })
-    return count ? BigInt(count) : 0n
-  }
 }
 
 export interface StateUpdateBundle {

--- a/packages/backend/src/peripherals/database/StateUpdateRepository.ts
+++ b/packages/backend/src/peripherals/database/StateUpdateRepository.ts
@@ -1,4 +1,4 @@
-import { AssetBalance, OraclePrice } from '@explorer/encoding'
+import { OraclePrice } from '@explorer/encoding'
 import {
   AssetId,
   Hash256,
@@ -7,14 +7,15 @@ import {
   Timestamp,
 } from '@explorer/types'
 import { Knex } from 'knex'
-import {
-  AssetBalanceJson,
-  PositionRow,
-  PriceRow,
-  StateUpdateRow,
-} from 'knex/types/tables'
+import { PriceRow, StateUpdateRow } from 'knex/types/tables'
 
 import { Logger } from '../../tools/Logger'
+import { BaseRepository } from './BaseRepository'
+import {
+  PositionRecord,
+  toPositionRow,
+  toPositionWithPricesRecord,
+} from './PositionRepository'
 
 export interface StateUpdateRecord {
   id: number
@@ -24,27 +25,17 @@ export interface StateUpdateRecord {
   timestamp: Timestamp
 }
 
-export interface PositionRecord {
-  positionId: bigint
-  publicKey: StarkKey
-  collateralBalance: bigint
-  balances: readonly AssetBalance[]
-}
-
-export interface PositionWithPricesRecord extends PositionRecord {
-  stateUpdateId: number
-  prices: { assetId: AssetId; price: bigint }[]
-}
-
 export interface StateUpdatePriceRecord {
   stateUpdateId: number
   assetId: AssetId
   price: bigint
 }
 
-export class StateUpdateRepository {
-  constructor(private knex: Knex, private logger: Logger) {
-    this.logger = logger.for(this)
+export class StateUpdateRepository extends BaseRepository {
+  constructor(knex: Knex, logger: Logger) {
+    super(knex, logger)
+    this.add = this.wrapAdd(this.add)
+    this.findLast = this.wrapFind(this.findLast)
   }
 
   async add({ stateUpdate, positions, prices }: StateUpdateBundle) {
@@ -60,48 +51,15 @@ export class StateUpdateRepository {
         await trx('prices').insert(
           prices.map((price) => toPriceRow(price, stateUpdate.id))
         )
-
-      this.logger.debug({
-        method: 'add',
-        id: stateUpdate.id,
-        blockNumber: stateUpdate.blockNumber,
-      })
     })
+    return stateUpdate.id
   }
 
-  async getLast(): Promise<StateUpdateRecord | undefined> {
+  async findLast(): Promise<StateUpdateRecord | undefined> {
     const row = await this.knex('state_updates')
       .orderBy('block_number', 'desc')
       .first()
-
-    this.logger.debug({ method: 'getLast', id: row?.id || null })
-
     return row && toStateUpdateRecord(row)
-  }
-
-  async getPositionHistoryById(positionId: bigint) {
-    const rows = await this.knex('positions')
-      .where('position_id', positionId)
-      .orderBy('positions.state_update_id', 'desc')
-      .join('prices', 'prices.state_update_id', 'positions.state_update_id')
-      .join('state_updates', 'state_updates.id', 'positions.state_update_id')
-      .groupBy(
-        'positions.position_id',
-        'positions.state_update_id',
-        'state_updates.timestamp'
-      )
-      .select(
-        'positions.*',
-        'state_updates.timestamp as timestamp',
-        this.knex.raw('array_agg(row_to_json(prices)) as prices')
-      )
-
-    return rows.map((r) => {
-      return {
-        ...toPositionWithPricesRecord(r),
-        timestamp: Timestamp(r.timestamp),
-      }
-    })
   }
 
   async getStateUpdateIdByRootHash(
@@ -275,56 +233,6 @@ function toStateUpdateRow(record: StateUpdateRecord): StateUpdateRow {
     fact_hash: record.factHash.toString(),
     root_hash: record.rootHash.toString(),
     timestamp: BigInt(Number(record.timestamp)),
-  }
-}
-
-function toPositionRecord(
-  row: PositionRow
-): PositionRecord & { stateUpdateId: number } {
-  return {
-    stateUpdateId: row.state_update_id,
-    positionId: BigInt(row.position_id),
-    publicKey: StarkKey(row.public_key),
-    collateralBalance: BigInt(row.collateral_balance),
-    balances: (typeof row.balances === 'string'
-      ? (JSON.parse(row.balances) as AssetBalanceJson[])
-      : row.balances
-    ).map((x) => ({
-      assetId: AssetId(x.asset_id),
-      balance: BigInt(x.balance),
-    })),
-  }
-}
-
-function toPositionWithPricesRecord(
-  row: PositionRow & { prices: PriceRow[] }
-): PositionWithPricesRecord {
-  return {
-    ...toPositionRecord(row),
-    prices: row.prices.filter(Boolean).map((p) => ({
-      assetId: AssetId(p.asset_id),
-      price: BigInt(p.price),
-    })),
-  }
-}
-
-function toPositionRow(
-  record: PositionRecord,
-  stateUpdateId: number
-): PositionRow {
-  const balances = record.balances.map(
-    (x): AssetBalanceJson => ({
-      asset_id: x.assetId.toString(),
-      balance: x.balance.toString(),
-    })
-  )
-
-  return {
-    state_update_id: stateUpdateId,
-    position_id: record.positionId,
-    public_key: record.publicKey.toString(),
-    collateral_balance: record.collateralBalance,
-    balances: JSON.stringify(balances),
   }
 }
 

--- a/packages/backend/src/peripherals/database/SyncStatusRepository.ts
+++ b/packages/backend/src/peripherals/database/SyncStatusRepository.ts
@@ -1,10 +1,10 @@
 import type { KeyValueStore } from './KeyValueStore'
 
 export class SyncStatusRepository {
-  constructor(private readonly store: KeyValueStore<'lastBlockNumberSynced'>) {}
+  constructor(private readonly store: KeyValueStore) {}
 
   async getLastSynced(): Promise<number | undefined> {
-    const valueInDb = await this.store.get('lastBlockNumberSynced')
+    const valueInDb = await this.store.findByKey('lastBlockNumberSynced')
     if (valueInDb) {
       const result = Number(valueInDb)
       if (!isNaN(result)) {
@@ -14,6 +14,9 @@ export class SyncStatusRepository {
   }
 
   async setLastSynced(blockNumber: number): Promise<void> {
-    await this.store.set('lastBlockNumberSynced', String(blockNumber))
+    await this.store.addOrUpdate({
+      key: 'lastBlockNumberSynced',
+      value: String(blockNumber),
+    })
   }
 }

--- a/packages/backend/src/peripherals/database/VerifierEventRepository.ts
+++ b/packages/backend/src/peripherals/database/VerifierEventRepository.ts
@@ -2,109 +2,72 @@ import { Knex } from 'knex'
 import { VerifierEventRow } from 'knex/types/tables'
 
 import { Logger } from '../../tools/Logger'
-import { Repository } from './types'
+import { BaseRepository } from './BaseRepository'
 
-export type VerifierEventRecord = (
-  | ImplementationAddedEventRecord
-  | UpgradedEventRecord
-) & {
-  id?: number
-}
-
-export interface ImplementationAddedEventRecord {
+export interface VerifierEventRecord {
+  id: number
+  name: 'ImplementationAdded' | 'Upgraded'
   implementation: string
-  initializer: string
+  initializer?: string
   blockNumber: number
-  name: 'ImplementationAdded'
 }
 
-export interface UpgradedEventRecord {
-  implementation: string
-  blockNumber: number
-  name: 'Upgraded'
-}
-
-export class VerifierEventRepository
-  implements Repository<VerifierEventRecord>
-{
-  constructor(private readonly knex: Knex, private readonly logger: Logger) {
-    this.logger = this.logger.for(this)
+export class VerifierEventRepository extends BaseRepository {
+  constructor(knex: Knex, logger: Logger) {
+    super(knex, logger)
+    this.addMany = this.wrapAddMany(this.addMany)
+    this.getAll = this.wrapGet(this.getAll)
+    this.deleteAll = this.wrapDelete(this.deleteAll)
+    this.deleteAfter = this.wrapDelete(this.deleteAfter)
   }
 
-  async add(records: VerifierEventRecord[]) {
-    if (records.length === 0) {
-      this.logger.debug({ method: 'add', rows: 0 })
-      return
-    }
-
-    const rows: VerifierEventRow[] = records.map(toRow)
-
-    await this.knex('verifier_events').insert(rows)
-
-    this.logger.debug({ method: 'add', rows: rows.length })
+  async addMany(records: Omit<VerifierEventRecord, 'id'>[]) {
+    const rows = records.map(toRow)
+    return this.knex('verifier_events').insert(rows).returning('id')
   }
 
   async getAll() {
     const rows = await this.knex('verifier_events').select('*')
-    this.logger.debug({ method: 'getAll', rows: rows.length })
-
     return rows.map(toRecord)
   }
 
   async deleteAll() {
-    await this.knex('verifier_events').delete()
-    this.logger.debug({ method: 'deleteAll' })
+    return this.knex('verifier_events').delete()
   }
 
-  async deleteAllAfter(blockNumber: number) {
-    const rowsCount = await this.knex('verifier_events')
+  async deleteAfter(blockNumber: number) {
+    return await this.knex('verifier_events')
       .where('block_number', '>', blockNumber)
       .delete()
-    this.logger.debug({ method: 'deleteAllAfter', rows: rowsCount })
   }
 }
 
-function toRow(record: VerifierEventRecord): VerifierEventRow {
-  switch (record.name) {
-    case 'ImplementationAdded':
-      return {
-        id: record.id,
-        block_number: record.blockNumber,
-        implementation: record.implementation,
-        initializer: record.initializer,
-        name: 'ImplementationAdded',
-      }
-    case 'Upgraded':
-      return {
-        id: record.id,
-        block_number: record.blockNumber,
-        implementation: record.implementation,
-        name: 'Upgraded',
-      }
+function toRow(
+  record: Omit<VerifierEventRecord, 'id'>
+): Omit<VerifierEventRow, 'id'> {
+  if (record.name === 'ImplementationAdded' && !record.initializer) {
+    throw new Error("'initializer' is required on ImplementationAdded event")
+  }
+  return {
+    name: record.name,
+    block_number: record.blockNumber,
+    implementation: record.implementation,
+    initializer: record.initializer,
   }
 }
 
 function toRecord(row: VerifierEventRow): VerifierEventRecord {
-  switch (row.name) {
-    case 'ImplementationAdded':
-      if (!row.initializer)
-        throw new Error(
-          "'initializer' is required on ImplmenedationAdded event"
-        )
-
-      return {
-        id: row.id,
-        implementation: row.implementation,
-        initializer: row.initializer,
-        blockNumber: row.block_number,
-        name: 'ImplementationAdded',
-      }
-    case 'Upgraded':
-      return {
-        id: row.id,
-        implementation: row.implementation,
-        blockNumber: row.block_number,
-        name: 'Upgraded',
-      }
+  if (row.name === 'ImplementationAdded' && !row.initializer) {
+    throw new Error("'initializer' is required on ImplementationAdded event")
   }
+  const record: VerifierEventRecord = {
+    id: row.id,
+    name: row.name,
+    implementation: row.implementation,
+    blockNumber: row.block_number,
+  }
+  if (row.initializer) {
+    record.initializer = row.initializer
+  }
+  return record
 }

--- a/packages/backend/src/peripherals/database/types.ts
+++ b/packages/backend/src/peripherals/database/types.ts
@@ -137,17 +137,10 @@ declare module 'knex/types/tables' {
   }
 }
 
-export interface Repository<TRecord> {
-  addOrUpdate?(records: TRecord[]): Promise<void>
-  add?(records: TRecord[]): Promise<void>
-  getAll(): Promise<TRecord[]>
-  deleteAll(): Promise<void>
-}
-
 /**
  * JSON object stored in a column of type `json` or `jsonb`.
  *
  * We need to pass arrays as stringified JSON to the database — https://knexjs.org/#Schema-jsonb.
- * But, when we receive it from the database, we get the JSON object alraedy partially parsed with JSON.parse.
+ * But, when we receive it from the database, we get the JSON object already partially parsed with JSON.parse.
  */
 export type JsonB<T> = T | string

--- a/packages/backend/src/peripherals/database/types.ts
+++ b/packages/backend/src/peripherals/database/types.ts
@@ -132,7 +132,7 @@ declare module 'knex/types/tables' {
     state_updates: StateUpdateRow
     positions: PositionRow
     prices: PriceRow
-    user_registration_evens: UserRegistrationEventRow
+    user_registration_events: UserRegistrationEventRow
     forced_transaction_events: ForcedTransactionEventRow
   }
 }

--- a/packages/backend/src/peripherals/database/types.ts
+++ b/packages/backend/src/peripherals/database/types.ts
@@ -11,7 +11,7 @@ declare module 'knex/types/tables' {
 
   interface VerifierEventRow {
     /** surrogate key */
-    id?: number
+    id: number
     implementation: string
     block_number: number
     name: 'ImplementationAdded' | 'Upgraded'

--- a/packages/backend/src/peripherals/database/types.ts
+++ b/packages/backend/src/peripherals/database/types.ts
@@ -29,7 +29,7 @@ declare module 'knex/types/tables' {
 
   interface PageRow {
     /** surrogate key */
-    id?: number
+    id: number
     block_number: number
     page_hash: string
     data: string

--- a/packages/backend/src/peripherals/database/types.ts
+++ b/packages/backend/src/peripherals/database/types.ts
@@ -37,7 +37,7 @@ declare module 'knex/types/tables' {
 
   interface StateTransitionFactRow {
     /** surrogate key */
-    id?: number
+    id: number
     block_number: number
     hash: string
   }

--- a/packages/backend/src/peripherals/database/types.ts
+++ b/packages/backend/src/peripherals/database/types.ts
@@ -20,7 +20,7 @@ declare module 'knex/types/tables' {
 
   interface FactToPageRow {
     /** surrogate key */
-    id?: number
+    id: number
     block_number: number
     fact_hash: string
     page_hash: string

--- a/packages/backend/test/api/routers/FrontendRouter.test.ts
+++ b/packages/backend/test/api/routers/FrontendRouter.test.ts
@@ -15,6 +15,7 @@ import { PositionController } from '../../../src/api/controllers/PositionControl
 import { SearchController } from '../../../src/api/controllers/SearchController'
 import { StateUpdateController } from '../../../src/api/controllers/StateUpdateController'
 import { createFrontendRouter } from '../../../src/api/routers/FrontendRouter'
+import { PositionRepository } from '../../../src/peripherals/database/PositionRepository'
 import { StateUpdateRepository } from '../../../src/peripherals/database/StateUpdateRepository'
 import { UserRegistrationEventRepository } from '../../../src/peripherals/database/UserRegistrationEventRepository'
 import { Logger } from '../../../src/tools/Logger'
@@ -204,6 +205,7 @@ describe('FrontendRouter', () => {
         knex,
         Logger.SILENT
       )
+      const positionRepository = new PositionRepository(knex, Logger.SILENT)
 
       const userRegistrationEventRepository =
         new UserRegistrationEventRepository(knex, Logger.SILENT)
@@ -237,6 +239,7 @@ describe('FrontendRouter', () => {
 
       const searchController = new SearchController(
         stateUpdateRepository,
+        positionRepository,
         userRegistrationEventRepository
       )
       const frontendRouter = createFrontendRouter(

--- a/packages/backend/test/api/routers/FrontendRouter.test.ts
+++ b/packages/backend/test/api/routers/FrontendRouter.test.ts
@@ -227,7 +227,7 @@ describe('FrontendRouter', () => {
         prices: [{ assetId: AssetId('ETH-9'), price: 40n }],
       })
 
-      await userRegistrationEventRepository.add([
+      await userRegistrationEventRepository.addMany([
         {
           blockNumber: 1,
           ethAddress,

--- a/packages/backend/test/core/DataSyncService.test.ts
+++ b/packages/backend/test/core/DataSyncService.test.ts
@@ -29,7 +29,7 @@ describe(DataSyncService.name, () => {
       collect: async (_blockRange) => [],
     })
 
-    const transitionFacts: StateTransitionFactRecord[] = [
+    const transitionFacts: Omit<StateTransitionFactRecord, 'id'>[] = [
       { hash: Hash256.fake('abcd'), blockNumber: 1 },
     ]
 

--- a/packages/backend/test/core/MemoryHashEventCollector.test.ts
+++ b/packages/backend/test/core/MemoryHashEventCollector.test.ts
@@ -18,7 +18,7 @@ describe(MemoryHashEventCollector.name, () => {
         testData().logs.filter((log) => filter.address === log.address),
     })
     const factToPageRepository = mock<FactToPageRepository>({
-      add: async () => {},
+      addMany: async () => [],
     })
     const collector = new MemoryHashEventCollector(
       ethereumClient,
@@ -129,7 +129,7 @@ describe(MemoryHashEventCollector.name, () => {
       ])
     }
 
-    expect(factToPageRepository.add).toHaveBeenCalledWith([
+    expect(factToPageRepository.addMany).toHaveBeenCalledWith([
       [
         {
           index: 0,
@@ -183,9 +183,9 @@ describe(MemoryHashEventCollector.name, () => {
     ])
   })
 
-  it('discards all records from factToPageRepostiory after given block', async () => {
+  it('discards all records from factToPageRepository after given block', async () => {
     const factToPageRepository = mock<FactToPageRepository>({
-      deleteAllAfter: async () => {},
+      deleteAllAfter: async () => 0,
     })
 
     const collector = new MemoryHashEventCollector(
@@ -204,7 +204,7 @@ describe(MemoryHashEventCollector.name, () => {
         testData().logs.filter((log) => filter.address === log.address),
     })
     const factToPageRepository = mock<FactToPageRepository>({
-      add: async () => {},
+      addMany: async () => [],
     })
     const collector = new MemoryHashEventCollector(
       ethereumClient,

--- a/packages/backend/test/core/PageCollector.test.ts
+++ b/packages/backend/test/core/PageCollector.test.ts
@@ -24,7 +24,7 @@ describe(PageCollector.name, () => {
       getLogsInRange: async () => testData().logs,
     })
     const pageRepository = mock<PageRepository>({
-      add: async () => {},
+      addMany: async () => [],
     })
 
     const pageCollector = new PageCollector(ethereumClient, pageRepository)
@@ -46,7 +46,7 @@ describe(PageCollector.name, () => {
 
     const actualRecords = await pageCollector.collect(blockRange)
 
-    const expectedRecords: PageRecord[] = [
+    const expectedRecords: Omit<PageRecord, 'id'>[] = [
       {
         blockNumber: 9,
         data: [5, 6, 7].map(BigNumber.from).map(bignumToPaddedString).join(''),
@@ -76,19 +76,19 @@ describe(PageCollector.name, () => {
       },
     ])
 
-    expect(pageRepository.add).toHaveBeenCalledWith([expectedRecords])
+    expect(pageRepository.addMany).toHaveBeenCalledWith([expectedRecords])
   })
 
   it('discards all records from repository after given block', async () => {
     const pageRepository = mock<PageRepository>({
-      deleteAllAfter: async () => {},
+      deleteAfter: async () => 0,
     })
 
     const collector = new PageCollector(mock<EthereumClient>(), pageRepository)
 
     await collector.discardAfter(123)
 
-    expect(pageRepository.deleteAllAfter).toHaveBeenCalledWith([123])
+    expect(pageRepository.deleteAfter).toHaveBeenCalledWith([123])
   })
 
   it('crashes on logs from reorged chain histories', async () => {
@@ -97,7 +97,7 @@ describe(PageCollector.name, () => {
       getLogs: async () => testData().logs,
     })
     const pageRepository = mock<PageRepository>({
-      add: async () => {},
+      addMany: async () => [],
     })
 
     const pageCollector = new PageCollector(ethereumClient, pageRepository)

--- a/packages/backend/test/core/StateTransitionFactCollector.test.ts
+++ b/packages/backend/test/core/StateTransitionFactCollector.test.ts
@@ -19,7 +19,7 @@ describe(StateTransitionFactCollector.name, () => {
       getLogsInRange: async () => testData().logs,
     })
     const transitionFactRepository = mock<StateTransitionFactRepository>({
-      add: async () => {},
+      addMany: async () => [],
     })
     const stateTransitionFactCollector = new StateTransitionFactCollector(
       ethereumClient,
@@ -55,7 +55,7 @@ describe(StateTransitionFactCollector.name, () => {
 
     const records = await stateTransitionFactCollector.collect(blockRange)
 
-    const expectedRecords: StateTransitionFactRecord[] = [
+    const expectedRecords: Omit<StateTransitionFactRecord, 'id'>[] = [
       {
         blockNumber: 13986068,
         hash: Hash256(
@@ -90,12 +90,14 @@ describe(StateTransitionFactCollector.name, () => {
         topics: [LOG_STATE_TRANSITION_FACT],
       },
     ])
-    expect(transitionFactRepository.add).toHaveBeenCalledWith([expectedRecords])
+    expect(transitionFactRepository.addMany).toHaveBeenCalledWith([
+      expectedRecords,
+    ])
   })
 
   it('discards all records from factToPageRepository after given block', async () => {
     const transitionFactRepository = mock<StateTransitionFactRepository>({
-      deleteAllAfter: async () => {},
+      deleteAfter: async () => 0,
     })
 
     const collector = new StateTransitionFactCollector(
@@ -105,7 +107,7 @@ describe(StateTransitionFactCollector.name, () => {
 
     await collector.discardAfter(123)
 
-    expect(transitionFactRepository.deleteAllAfter).toHaveBeenCalledWith([123])
+    expect(transitionFactRepository.deleteAfter).toHaveBeenCalledWith([123])
   })
 
   it('crashes on logs from reorged chain histories', async () => {
@@ -113,7 +115,7 @@ describe(StateTransitionFactCollector.name, () => {
       getLogs: async () => testData().logs,
     })
     const transitionFactRepository = mock<StateTransitionFactRepository>({
-      add: async () => {},
+      addMany: async () => [],
     })
     const stateTransitionFactCollector = new StateTransitionFactCollector(
       ethereumClient,

--- a/packages/backend/test/core/StateUpdateCollector.test.ts
+++ b/packages/backend/test/core/StateUpdateCollector.test.ts
@@ -105,9 +105,7 @@ describe(StateUpdateCollector.name, () => {
         mock<ForcedTransactionsRepository>()
       )
       expect(
-        stateUpdateCollector.save([
-          { id: 1, hash: Hash256.fake('a'), blockNumber: 1 },
-        ])
+        stateUpdateCollector.save([{ hash: Hash256.fake('a'), blockNumber: 1 }])
       ).toBeRejected('Missing state transition facts in database')
     })
 

--- a/packages/backend/test/core/StateUpdateCollector.test.ts
+++ b/packages/backend/test/core/StateUpdateCollector.test.ts
@@ -117,7 +117,7 @@ describe(StateUpdateCollector.name, () => {
         ],
       })
       const stateUpdateRepository = mock<StateUpdateRepository>({
-        getLast: async () => ({
+        findLast: async () => ({
           rootHash: PedersenHash.fake('1234'),
           id: 567,
           timestamp: Timestamp(1),

--- a/packages/backend/test/core/StateUpdateCollector.test.ts
+++ b/packages/backend/test/core/StateUpdateCollector.test.ts
@@ -189,7 +189,7 @@ describe(StateUpdateCollector.name, () => {
   describe(StateUpdateCollector.prototype.discardAfter.name, () => {
     it('deletes updates after block number', async () => {
       const stateUpdateRepository = mock<StateUpdateRepository>({
-        deleteAfter: async () => {},
+        deleteAfter: async () => 0,
       })
 
       const stateUpdateCollector = new StateUpdateCollector(

--- a/packages/backend/test/core/StateUpdateCollector.test.ts
+++ b/packages/backend/test/core/StateUpdateCollector.test.ts
@@ -95,7 +95,7 @@ describe(StateUpdateCollector.name, () => {
   describe(StateUpdateCollector.prototype.save.name, () => {
     it('throws if state transition facts are missing in database', async () => {
       const pageRepository = mock<PageRepository>({
-        getAllForFacts: async () => [],
+        getByFactHashes: async () => [],
       })
       const stateUpdateCollector = new StateUpdateCollector(
         pageRepository,
@@ -113,7 +113,7 @@ describe(StateUpdateCollector.name, () => {
 
     it('calls processStateTransition for every update', async () => {
       const pageRepository = mock<PageRepository>({
-        getAllForFacts: async () => [
+        getByFactHashes: async () => [
           { factHash: Hash256.fake('a'), pages: ['aa', 'ab', 'ac'] },
           { factHash: Hash256.fake('b'), pages: ['ba', 'bb'] },
         ],

--- a/packages/backend/test/core/StateUpdateCollector.test.ts
+++ b/packages/backend/test/core/StateUpdateCollector.test.ts
@@ -189,7 +189,7 @@ describe(StateUpdateCollector.name, () => {
   describe(StateUpdateCollector.prototype.discardAfter.name, () => {
     it('deletes updates after block number', async () => {
       const stateUpdateRepository = mock<StateUpdateRepository>({
-        deleteAllAfter: async () => {},
+        deleteAfter: async () => {},
       })
 
       const stateUpdateCollector = new StateUpdateCollector(
@@ -205,7 +205,7 @@ describe(StateUpdateCollector.name, () => {
       await stateUpdateCollector.discardAfter(20)
       await stateUpdateCollector.discardAfter(40)
 
-      expect(stateUpdateRepository.deleteAllAfter).toHaveBeenCalledExactlyWith([
+      expect(stateUpdateRepository.deleteAfter).toHaveBeenCalledExactlyWith([
         [20],
         [40],
       ])

--- a/packages/backend/test/core/UserRegistrationCollector.test.ts
+++ b/packages/backend/test/core/UserRegistrationCollector.test.ts
@@ -66,7 +66,7 @@ describe(UserRegistrationCollector.name, () => {
       getLogsInRange: async () => TEST_LOGS,
     })
     const repository = mock<UserRegistrationEventRepository>({
-      add: async () => {},
+      addMany: async () => [],
     })
     const collector = new UserRegistrationCollector(ethereumClient, repository)
 
@@ -104,7 +104,9 @@ describe(UserRegistrationCollector.name, () => {
       },
     ]
 
-    expect(repository.add).toHaveBeenCalledWith([expectedRegistrationEvents])
+    expect(repository.addMany).toHaveBeenCalledWith([
+      expectedRegistrationEvents,
+    ])
 
     expect(registrations).toEqual(
       expectedRegistrationEvents.map((e) => ({
@@ -116,7 +118,7 @@ describe(UserRegistrationCollector.name, () => {
 
   it('discards all records from repository after given block', async () => {
     const userRegistrationRepository = mock<UserRegistrationEventRepository>({
-      deleteAllAfter: async (_blockNumber: number) => {},
+      deleteAfter: async () => 0,
     })
     const collector = new UserRegistrationCollector(
       mock<EthereumClient>(),
@@ -125,8 +127,6 @@ describe(UserRegistrationCollector.name, () => {
 
     await collector.discardAfter(123)
 
-    expect(userRegistrationRepository.deleteAllAfter).toHaveBeenCalledWith([
-      123,
-    ])
+    expect(userRegistrationRepository.deleteAfter).toHaveBeenCalledWith([123])
   })
 })

--- a/packages/backend/test/core/VerifierCollector.test.ts
+++ b/packages/backend/test/core/VerifierCollector.test.ts
@@ -12,7 +12,7 @@ import { mock } from '../mock'
 
 describe(VerifierCollector.name, () => {
   it('saves events to repository and returns verifier addresses', async () => {
-    const add = mockFn(async (_records: VerifierEventRecord[]) => {})
+    const addMany = mockFn(async (_records: VerifierEventRecord[]) => [])
 
     const ethereumClient = mock<EthereumClient>({
       getLogsInRange: async () => testData().logs,
@@ -20,7 +20,7 @@ describe(VerifierCollector.name, () => {
     const collector = new VerifierCollector(
       ethereumClient,
       mock<VerifierEventRepository>({
-        add,
+        addMany,
         async getAll() {
           return []
         },
@@ -70,7 +70,7 @@ describe(VerifierCollector.name, () => {
         ],
       },
     ])
-    expect(add).toHaveBeenCalledWith([
+    expect(addMany).toHaveBeenCalledWith([
       [
         expect.objectWith({
           name: 'ImplementationAdded',
@@ -107,7 +107,7 @@ describe(VerifierCollector.name, () => {
 
   it('discards all records from repository after given block', async () => {
     const verifierEventRepository = mock<VerifierEventRepository>({
-      deleteAllAfter: async (_blockNumber: number) => {},
+      deleteAfter: async (_blockNumber: number) => 0,
     })
     const collector = new VerifierCollector(
       mock<EthereumClient>(),
@@ -116,12 +116,12 @@ describe(VerifierCollector.name, () => {
 
     await collector.discardAfter(123)
 
-    expect(verifierEventRepository.deleteAllAfter).toHaveBeenCalledWith([123])
+    expect(verifierEventRepository.deleteAfter).toHaveBeenCalledWith([123])
   })
 
   it('crashes on logs from reorged chain histories', async () => {
     const verifierEventRepository = mock<VerifierEventRepository>({
-      add: async () => {},
+      addMany: async () => [],
       getAll: async () => [],
     })
 
@@ -153,7 +153,7 @@ describe(VerifierCollector.name, () => {
     const collector = new VerifierCollector(
       mock<EthereumClient>({ getLogsInRange: async () => [] }),
       mock<VerifierEventRepository>({
-        add: async () => {},
+        addMany: async () => [],
         getAll: async () => [],
       }),
       hardcodedAddresses

--- a/packages/backend/test/core/sync/BlockDownloader.test.ts
+++ b/packages/backend/test/core/sync/BlockDownloader.test.ts
@@ -249,7 +249,7 @@ describe(BlockDownloader.name, () => {
 
     function mockBlockRepository(blocks: BlockRecord[]) {
       return mock<BlockRepository>({
-        deleteAllAfter: async () => 0,
+        deleteAfter: async () => 0,
         addMany: async () => [],
         findByNumber: async (number: number) => {
           return blocks.find((x) => x.number === number)
@@ -320,7 +320,7 @@ describe(BlockDownloader.name, () => {
       const result = await blockDownloader.testAdvanceChain(BLOCK_C1.number)
       expect(result).toEqual(['reorg', [record(BLOCK_B1), record(BLOCK_C1)]])
       expect(blockDownloader.getLastKnown()).toEqual(BLOCK_C1.number)
-      expect(blockRepository.deleteAllAfter).toHaveBeenCalledExactlyWith([
+      expect(blockRepository.deleteAfter).toHaveBeenCalledExactlyWith([
         [BLOCK_A.number],
       ])
       expect(blockRepository.addMany).toHaveBeenCalledExactlyWith([
@@ -358,7 +358,7 @@ describe(BlockDownloader.name, () => {
         ],
       ])
       expect(blockDownloader.getLastKnown()).toEqual(BLOCK_E1.number)
-      expect(blockRepository.deleteAllAfter).toHaveBeenCalledExactlyWith([
+      expect(blockRepository.deleteAfter).toHaveBeenCalledExactlyWith([
         [BLOCK_A.number],
       ])
       expect(blockRepository.addMany).toHaveBeenCalledExactlyWith([

--- a/packages/backend/test/core/sync/BlockDownloader.test.ts
+++ b/packages/backend/test/core/sync/BlockDownloader.test.ts
@@ -26,7 +26,7 @@ describe(BlockDownloader.name, () => {
         },
       })
       const blockRepository = mock<BlockRepository>({
-        getLast: async () =>
+        findLast: async () =>
           lastBlockNumber
             ? { hash: Hash256.fake(), number: lastBlockNumber }
             : undefined,
@@ -154,7 +154,7 @@ describe(BlockDownloader.name, () => {
         onBlock: () => () => {},
       })
       const blockRepository = mock<BlockRepository>({
-        getLast: async () => ({ hash: Hash256.fake(), number: 10_000_000 }),
+        findLast: async () => ({ hash: Hash256.fake(), number: 10_000_000 }),
       })
       const blockDownloader = new BlockDownloader(
         ethereumClient,
@@ -176,7 +176,7 @@ describe(BlockDownloader.name, () => {
     it('returns no blocks if the repository is empty', async () => {
       const ethereumClient = mock<EthereumClient>()
       const blockRepository = mock<BlockRepository>({
-        getLast: async () => undefined,
+        findLast: async () => undefined,
       })
       const blockDownloader = new BlockDownloader(
         ethereumClient,
@@ -189,7 +189,7 @@ describe(BlockDownloader.name, () => {
     it('returns no blocks if there are no blocks in range', async () => {
       const ethereumClient = mock<EthereumClient>()
       const blockRepository = mock<BlockRepository>({
-        getLast: async () => ({ number: 2_000_000, hash: Hash256.fake() }),
+        findLast: async () => ({ number: 2_000_000, hash: Hash256.fake() }),
         getAllInRange: async () => [],
       })
       const blockDownloader = new BlockDownloader(
@@ -203,7 +203,7 @@ describe(BlockDownloader.name, () => {
     it('returns the blocks in range', async () => {
       const ethereumClient = mock<EthereumClient>()
       const blockRepository = mock<BlockRepository>({
-        getLast: async () => ({ number: 2_000_000, hash: Hash256.fake() }),
+        findLast: async () => ({ number: 2_000_000, hash: Hash256.fake() }),
         getAllInRange: async () => [
           { number: 1_500_000, hash: Hash256.fake('abc') },
           { number: 1_700_000, hash: Hash256.fake('def') },
@@ -249,9 +249,9 @@ describe(BlockDownloader.name, () => {
 
     function mockBlockRepository(blocks: BlockRecord[]) {
       return mock<BlockRepository>({
-        deleteAllAfter: async () => {},
-        add: async () => {},
-        getByNumber: async (number: number) => {
+        deleteAllAfter: async () => 0,
+        addMany: async () => [],
+        findByNumber: async (number: number) => {
           return blocks.find((x) => x.number === number)
         },
       })
@@ -285,7 +285,7 @@ describe(BlockDownloader.name, () => {
       const result = await blockDownloader.testAdvanceChain(BLOCK_B.number)
       expect(result).toEqual(['newBlock', record(BLOCK_B)])
       expect(blockDownloader.getLastKnown()).toEqual(BLOCK_B.number)
-      expect(blockRepository.add).toHaveBeenCalledExactlyWith([
+      expect(blockRepository.addMany).toHaveBeenCalledExactlyWith([
         [[record(BLOCK_B)]],
       ])
     })
@@ -302,7 +302,7 @@ describe(BlockDownloader.name, () => {
       const result = await blockDownloader.testAdvanceChain(BLOCK_B.number)
       expect(result).toEqual(['newBlock', record(BLOCK_B)])
       expect(blockDownloader.getLastKnown()).toEqual(BLOCK_B.number)
-      expect(blockRepository.add).toHaveBeenCalledExactlyWith([
+      expect(blockRepository.addMany).toHaveBeenCalledExactlyWith([
         [[record(BLOCK_A)]],
         [[record(BLOCK_B)]],
       ])
@@ -323,7 +323,7 @@ describe(BlockDownloader.name, () => {
       expect(blockRepository.deleteAllAfter).toHaveBeenCalledExactlyWith([
         [BLOCK_A.number],
       ])
-      expect(blockRepository.add).toHaveBeenCalledExactlyWith([
+      expect(blockRepository.addMany).toHaveBeenCalledExactlyWith([
         [[record(BLOCK_B1), record(BLOCK_C1)]],
       ])
     })
@@ -361,7 +361,7 @@ describe(BlockDownloader.name, () => {
       expect(blockRepository.deleteAllAfter).toHaveBeenCalledExactlyWith([
         [BLOCK_A.number],
       ])
-      expect(blockRepository.add).toHaveBeenCalledExactlyWith([
+      expect(blockRepository.addMany).toHaveBeenCalledExactlyWith([
         [
           [
             record(BLOCK_B1),

--- a/packages/backend/test/peripherals/database/BlockRepository.test.ts
+++ b/packages/backend/test/peripherals/database/BlockRepository.test.ts
@@ -18,7 +18,7 @@ describe(BlockRepository.name, () => {
   it('adds single record and queries it', async () => {
     const record: BlockRecord = { number: 1, hash: Hash256.fake() }
 
-    await repository.add([record])
+    await repository.addMany([record])
 
     const actual = await repository.getAll()
 
@@ -26,7 +26,7 @@ describe(BlockRepository.name, () => {
   })
 
   it('adds 0 records', async () => {
-    await repository.add([])
+    await repository.addMany([])
     expect(await repository.getAll()).toEqual([])
   })
 
@@ -37,14 +37,14 @@ describe(BlockRepository.name, () => {
       { number: 3, hash: Hash256.fake() },
     ]
 
-    await repository.add(records)
+    await repository.addMany(records)
     const actual = await repository.getAll()
 
     expect(actual).toEqual(records)
   })
 
   it('deletes all records', async () => {
-    await repository.add([
+    await repository.addMany([
       { number: 1, hash: Hash256.fake() },
       { number: 2, hash: Hash256.fake() },
     ])
@@ -60,7 +60,7 @@ describe(BlockRepository.name, () => {
       hash: Hash256.fake(),
       number: i,
     }))
-    await repository.add(records)
+    await repository.addMany(records)
 
     await repository.deleteAllAfter(5)
 
@@ -71,36 +71,36 @@ describe(BlockRepository.name, () => {
   it('gets by hash', async () => {
     const record = { number: 1, hash: Hash256.fake() }
 
-    await repository.add([record])
+    await repository.addMany([record])
 
-    expect(await repository.getByHash(record.hash)).toEqual(record)
+    expect(await repository.findByHash(record.hash)).toEqual(record)
 
-    expect(await repository.getByHash(Hash256.fake('000'))).toEqual(undefined)
+    expect(await repository.findByHash(Hash256.fake('000'))).toEqual(undefined)
   })
 
   it('gets by number', async () => {
     const record = { number: 1, hash: Hash256.fake() }
 
-    await repository.add([record])
+    await repository.addMany([record])
 
-    expect(await repository.getByNumber(record.number)).toEqual(record)
+    expect(await repository.findByNumber(record.number)).toEqual(record)
 
-    expect(await repository.getByNumber(2)).toEqual(undefined)
+    expect(await repository.findByNumber(2)).toEqual(undefined)
   })
 
   it('gets last by number', async () => {
-    expect(await repository.getLast()).toEqual(undefined)
+    expect(await repository.findLast()).toEqual(undefined)
 
     const block = { number: 11813208, hash: Hash256.fake() }
-    await repository.add([block])
+    await repository.addMany([block])
 
-    expect(await repository.getLast()).toEqual(block)
+    expect(await repository.findLast()).toEqual(block)
 
     const earlierBlock = { number: 11813206, hash: Hash256.fake() }
     const laterBlock = { number: 11813209, hash: Hash256.fake() }
-    await repository.add([laterBlock, earlierBlock])
+    await repository.addMany([laterBlock, earlierBlock])
 
-    expect(await repository.getLast()).toEqual(laterBlock)
+    expect(await repository.findLast()).toEqual(laterBlock)
   })
 
   it('gets all blocks in range between given numbers (inclusive)', async () => {
@@ -108,7 +108,7 @@ describe(BlockRepository.name, () => {
       number: i,
       hash: Hash256.fake(),
     }))
-    await repository.add(blocks)
+    await repository.addMany(blocks)
 
     expect(await repository.getAllInRange(13, 17)).toEqual([
       blocks[3],

--- a/packages/backend/test/peripherals/database/BlockRepository.test.ts
+++ b/packages/backend/test/peripherals/database/BlockRepository.test.ts
@@ -62,7 +62,7 @@ describe(BlockRepository.name, () => {
     }))
     await repository.addMany(records)
 
-    await repository.deleteAllAfter(5)
+    await repository.deleteAfter(5)
 
     const actual = await repository.getAll()
     expect(actual).toEqual(records.filter((r) => r.number <= 5))

--- a/packages/backend/test/peripherals/database/FactToPageRepository.test.ts
+++ b/packages/backend/test/peripherals/database/FactToPageRepository.test.ts
@@ -15,14 +15,14 @@ describe(FactToPageRepository.name, () => {
   afterEach(() => repository.deleteAll())
 
   it('adds single record and queries it', async () => {
-    const record: FactToPageRecord = {
+    const record: Omit<FactToPageRecord, 'id'> = {
       blockNumber: 1,
       index: 0,
       factHash: Hash256.fake(),
       pageHash: Hash256.fake(),
     }
 
-    await repository.add([record])
+    await repository.addMany([record])
 
     const actual = await repository.getAll()
 
@@ -35,25 +35,25 @@ describe(FactToPageRepository.name, () => {
   })
 
   it('adds 0 records', async () => {
-    await repository.add([])
+    await repository.addMany([])
     expect(await repository.getAll()).toEqual([])
   })
 
   it('adds multiple records and queries them', async () => {
-    const records: FactToPageRecord[] = [
+    const records = [
       dummyFactToPageRecord({ index: 0 }),
       dummyFactToPageRecord({ index: 1 }),
       dummyFactToPageRecord({ index: 2 }),
     ]
 
-    await repository.add(records)
+    await repository.addMany(records)
     const actual = await repository.getAll()
 
     expect(actual).toEqual(records.map((r) => ({ ...r, id: expect.a(Number) })))
   })
 
   it('deletes all records', async () => {
-    await repository.add([
+    await repository.addMany([
       dummyFactToPageRecord({ index: 0 }),
       dummyFactToPageRecord({ index: 1 }),
     ])
@@ -68,7 +68,7 @@ describe(FactToPageRepository.name, () => {
     const records = Array.from({ length: 10 }).map((_, i) =>
       dummyFactToPageRecord({ blockNumber: i })
     )
-    await repository.add(records)
+    await repository.addMany(records)
 
     await repository.deleteAllAfter(5)
 
@@ -80,14 +80,12 @@ describe(FactToPageRepository.name, () => {
 })
 
 function dummyFactToPageRecord({
-  id,
   blockNumber = 0,
   index = 0,
   pageHash = Hash256.fake(),
   factHash = Hash256.fake(),
-}: Partial<FactToPageRecord>): FactToPageRecord {
+}: Partial<FactToPageRecord>): Omit<FactToPageRecord, 'id'> {
   return {
-    id,
     blockNumber,
     index,
     pageHash,

--- a/packages/backend/test/peripherals/database/KeyValueStore.test.ts
+++ b/packages/backend/test/peripherals/database/KeyValueStore.test.ts
@@ -1,4 +1,3 @@
-import { AssertTrue, IsExact } from 'conditional-type-checks'
 import { expect } from 'earljs'
 
 import { KeyValueStore } from '../../../src/peripherals/database/KeyValueStore'
@@ -7,23 +6,22 @@ import { setupDatabaseTestSuite } from './setup'
 
 describe(KeyValueStore.name, () => {
   const { knex } = setupDatabaseTestSuite()
-  type TestKey = '1' | '2' | '3' | 'key'
-  const kvStore = new KeyValueStore<TestKey>(knex, Logger.SILENT)
+  const kvStore = new KeyValueStore(knex, Logger.SILENT)
 
   afterEach(() => kvStore.deleteAll())
 
   it('sets and reads value', async () => {
-    kvStore.set('key', 'value')
-    const actual = await kvStore.get('key')
+    kvStore.addOrUpdate({ key: 'key', value: 'value' })
+    const actual = await kvStore.findByKey('key')
     expect(actual).toEqual('value')
-    await kvStore.delete('key')
+    await kvStore.deleteByKey('key')
   })
 
   it('reads and removes all values', async () => {
     await Promise.all([
-      kvStore.set('1', 'one'),
-      kvStore.set('2', 'two'),
-      kvStore.set('3', 'three'),
+      kvStore.addOrUpdate({ key: '1', value: 'one' }),
+      kvStore.addOrUpdate({ key: '2', value: 'two' }),
+      kvStore.addOrUpdate({ key: '3', value: 'three' }),
     ])
 
     let actual = await kvStore.getAll()
@@ -38,9 +36,4 @@ describe(KeyValueStore.name, () => {
     actual = await kvStore.getAll()
     expect(actual).toEqual([])
   })
-
-  // it constrains key type to generic parameter passed to constructor
-  type _ = AssertTrue<
-    IsExact<Parameters<typeof kvStore['set']>[0], '1' | '2' | '3' | 'key'>
-  >
 })

--- a/packages/backend/test/peripherals/database/PageRepository.test.ts
+++ b/packages/backend/test/peripherals/database/PageRepository.test.ts
@@ -19,13 +19,13 @@ describe(PageRepository.name, () => {
   afterEach(() => repository.deleteAll())
 
   it('adds single record and queries it', async () => {
-    const record: PageRecord = {
+    const record: Omit<PageRecord, 'id'> = {
       blockNumber: 1,
       pageHash: Hash256.fake(),
       data: '11223344',
     }
 
-    await repository.add([record])
+    await repository.addMany([record])
 
     const actual = await repository.getAll()
 
@@ -38,16 +38,16 @@ describe(PageRepository.name, () => {
   })
 
   it('adds multiple records and queries them', async () => {
-    const records: PageRecord[] = [dummyPage(10), dummyPage(11), dummyPage(12)]
+    const records = [dummyPage(10), dummyPage(11), dummyPage(12)]
 
-    await repository.add(records)
+    await repository.addMany(records)
     const actual = await repository.getAll()
 
     expect(actual).toEqual(records.map((r) => ({ ...r, id: expect.a(Number) })))
   })
 
   it('deletes all records', async () => {
-    await repository.add([dummyPage(1), dummyPage(2)])
+    await repository.addMany([dummyPage(1), dummyPage(2)])
 
     await repository.deleteAll()
 
@@ -57,9 +57,9 @@ describe(PageRepository.name, () => {
 
   it('deletes all records after a block number', async () => {
     const records = Array.from({ length: 10 }).map((_, i) => dummyPage(i))
-    await repository.add(records)
+    await repository.addMany(records)
 
-    await repository.deleteAllAfter(5)
+    await repository.deleteAfter(5)
 
     const actual = await repository.getAll()
     expect(actual).toEqual(
@@ -86,7 +86,7 @@ describe(PageRepository.name, () => {
         dummyFactToPage(100, Hash256.fake('ff01'), Hash256.fake('aa14'), 4),
       ])
 
-      await repository.add([
+      await repository.addMany([
         dummyPage(2, Hash256.fake('aa10'), '{{1-1}}'),
         dummyPage(1, Hash256.fake('aa11'), '{{1-2}}'),
         dummyPage(3, Hash256.fake('aa12'), '{{1-3}}'),
@@ -99,7 +99,7 @@ describe(PageRepository.name, () => {
         dummyPage(2, Hash256.fake('aa23'), '{{2-4}}'),
       ])
 
-      const actual = await repository.getAllForFacts([
+      const actual = await repository.getByFactHashes([
         Hash256.fake('ff02'),
         Hash256.fake('ff01'),
       ])
@@ -120,7 +120,7 @@ describe(PageRepository.name, () => {
         dummyFactToPage(300, Hash256.fake('ff03'), Hash256.fake('aa31'), 1),
       ])
 
-      await repository.add([
+      await repository.addMany([
         dummyPage(2, Hash256.fake('aa10'), '{{1-0}}'),
         dummyPage(1, Hash256.fake('aa11'), '{{1-1}}'),
         dummyPage(2, Hash256.fake('aa20'), '{{2-0}}'),
@@ -129,7 +129,7 @@ describe(PageRepository.name, () => {
         dummyPage(2, Hash256.fake('aa31'), '{{3-1}}'),
       ])
 
-      const actual = await repository.getAllForFacts([
+      const actual = await repository.getByFactHashes([
         Hash256.fake('ff01'),
         Hash256.fake('ff02'),
         Hash256.fake('ff03'),
@@ -158,7 +158,7 @@ describe(PageRepository.name, () => {
         dummyFactToPage(600, Hash256.fake('ff03'), Hash256.fake('cc11'), 0),
       ])
 
-      await repository.add([
+      await repository.addMany([
         dummyPage(90, Hash256.fake('aa11'), '{{old-1}}'),
         dummyPage(90, Hash256.fake('aa22'), '{{old-2}}'),
         dummyPage(190, Hash256.fake('aa11'), '{{new-1}}'),
@@ -169,7 +169,7 @@ describe(PageRepository.name, () => {
         dummyPage(412, Hash256.fake('cc22'), '{{3-2}}'),
       ])
 
-      const actual = await repository.getAllForFacts([
+      const actual = await repository.getByFactHashes([
         Hash256.fake('ff01'),
         Hash256.fake('ff02'),
         Hash256.fake('ff03'),
@@ -194,7 +194,7 @@ function dummyPage(
   blockNumber: number,
   pageHash = Hash256.fake(),
   data = `{{ data ${blockNumber} }}`
-): PageRecord {
+): Omit<PageRecord, 'id'> {
   return {
     blockNumber,
     pageHash,

--- a/packages/backend/test/peripherals/database/PageRepository.test.ts
+++ b/packages/backend/test/peripherals/database/PageRepository.test.ts
@@ -73,7 +73,7 @@ describe(PageRepository.name, () => {
     afterEach(() => factToPageRepository.deleteAll())
 
     it('gets pages for ordered by .index and fact hash position in array #1', async () => {
-      await factToPageRepository.add([
+      await factToPageRepository.addMany([
         dummyFactToPage(200, Hash256.fake('ff02'), Hash256.fake('aa22'), 2),
         dummyFactToPage(100, Hash256.fake('ff01'), Hash256.fake('aa13'), 3),
         dummyFactToPage(200, Hash256.fake('ff02'), Hash256.fake('aa20'), 0),
@@ -111,7 +111,7 @@ describe(PageRepository.name, () => {
     })
 
     it('gets pages for ordered by .index and fact hash position in array #2', async () => {
-      await factToPageRepository.add([
+      await factToPageRepository.addMany([
         dummyFactToPage(200, Hash256.fake('ff02'), Hash256.fake('aa20'), 0),
         dummyFactToPage(100, Hash256.fake('ff01'), Hash256.fake('aa11'), 1),
         dummyFactToPage(300, Hash256.fake('ff03'), Hash256.fake('aa30'), 0),
@@ -143,7 +143,7 @@ describe(PageRepository.name, () => {
     })
 
     it('handles multiple mappings and pages', async () => {
-      await factToPageRepository.add([
+      await factToPageRepository.addMany([
         dummyFactToPage(100, Hash256.fake('ff01'), Hash256.fake('aa11'), 0),
         dummyFactToPage(100, Hash256.fake('ff01'), Hash256.fake('aa22'), 1),
         dummyFactToPage(200, Hash256.fake('ff01'), Hash256.fake('aa11'), 0),
@@ -207,7 +207,7 @@ function dummyFactToPage(
   factHash: Hash256,
   pageHash: Hash256,
   index: number
-): FactToPageRecord {
+): Omit<FactToPageRecord, 'id'> {
   return {
     blockNumber,
     factHash,

--- a/packages/backend/test/peripherals/database/PositionRepository.test.ts
+++ b/packages/backend/test/peripherals/database/PositionRepository.test.ts
@@ -1,0 +1,47 @@
+import { Hash256, PedersenHash, StarkKey, Timestamp } from '@explorer/types'
+import { expect } from 'earljs'
+
+import { PositionRepository } from '../../../src/peripherals/database/PositionRepository'
+import { StateUpdateRepository } from '../../../src/peripherals/database/StateUpdateRepository'
+import { Logger, LogLevel } from '../../../src/tools/Logger'
+import { setupDatabaseTestSuite } from './setup'
+
+describe(StateUpdateRepository.name, () => {
+  const { knex } = setupDatabaseTestSuite()
+
+  const logger = new Logger({ format: 'pretty', logLevel: LogLevel.ERROR })
+  const stateUpdateRepository = new StateUpdateRepository(knex, logger)
+  const positionRepository = new PositionRepository(knex, logger)
+
+  afterEach(() => stateUpdateRepository.deleteAll())
+
+  it('returns the count of all positions', async () => {
+    const fakeUpdate = (id: number) => ({
+      id,
+      blockNumber: id * 1000,
+      rootHash: PedersenHash.fake(),
+      factHash: Hash256.fake(),
+      timestamp: Timestamp(0),
+    })
+    const fakePosition = (id: bigint) => ({
+      publicKey: StarkKey.fake(),
+      positionId: id,
+      collateralBalance: 0n,
+      balances: [],
+    })
+
+    await stateUpdateRepository.add({
+      stateUpdate: fakeUpdate(1),
+      positions: [fakePosition(123n), fakePosition(456n)],
+      prices: [],
+    })
+    await stateUpdateRepository.add({
+      stateUpdate: fakeUpdate(2),
+      positions: [fakePosition(456n), fakePosition(789n)],
+      prices: [],
+    })
+
+    const count = await positionRepository.count()
+    expect(count).toEqual(3n)
+  })
+})

--- a/packages/backend/test/peripherals/database/StateTransitionFactsRepository.test.ts
+++ b/packages/backend/test/peripherals/database/StateTransitionFactsRepository.test.ts
@@ -17,7 +17,7 @@ describe(StateTransitionFactRepository.name, () => {
   it('adds single record and queries it', async () => {
     const record = dummyRecord({ blockNumber: 1 })
 
-    await repository.add([record])
+    await repository.addMany([record])
 
     const actual = await repository.getAll()
 
@@ -36,19 +36,19 @@ describe(StateTransitionFactRepository.name, () => {
       dummyRecord({ blockNumber: 3 }),
     ]
 
-    await repository.add(records)
+    await repository.addMany(records)
     const actual = await repository.getAll()
 
     expect(actual).toEqual(records.map((r) => ({ ...r, id: expect.a(Number) })))
   })
 
   it('adds 0 records', async () => {
-    await repository.add([])
+    await repository.addMany([])
     expect(await repository.getAll()).toEqual([])
   })
 
   it('deletes all records', async () => {
-    await repository.add([
+    await repository.addMany([
       dummyRecord({ blockNumber: 1 }),
       dummyRecord({ blockNumber: 2 }),
       dummyRecord({ blockNumber: 3 }),
@@ -68,9 +68,9 @@ describe(StateTransitionFactRepository.name, () => {
       dummyRecord({ blockNumber: 4 }),
       dummyRecord({ blockNumber: 5 }),
     ]
-    await repository.add(records)
+    await repository.addMany(records)
 
-    await repository.deleteAllAfter(2)
+    await repository.deleteAfter(2)
 
     const actual = await repository.getAll()
     expect(actual).toEqual(
@@ -80,9 +80,11 @@ describe(StateTransitionFactRepository.name, () => {
 })
 
 function dummyRecord({
-  id,
   blockNumber = 0,
   hash = Hash256.fake(),
-}: Partial<StateTransitionFactRecord>): StateTransitionFactRecord {
-  return { id, blockNumber, hash }
+}: Partial<Omit<StateTransitionFactRecord, 'id'>>): Omit<
+  StateTransitionFactRecord,
+  'id'
+> {
+  return { blockNumber, hash }
 }

--- a/packages/backend/test/peripherals/database/StateUpdateRepository.test.ts
+++ b/packages/backend/test/peripherals/database/StateUpdateRepository.test.ts
@@ -46,27 +46,18 @@ describe(StateUpdateRepository.name, () => {
   })
 
   it('gets state update id by root hash', async () => {
-    const stateRootId = 1
-    const positionId = 12345n
     const rootHash = PedersenHash.fake()
 
     await repository.add({
       stateUpdate: {
-        id: stateRootId,
+        id: 1,
         blockNumber: 1,
         rootHash,
         factHash: Hash256.fake(),
         timestamp: Timestamp(0),
       },
-      positions: [
-        {
-          publicKey: StarkKey.fake(),
-          positionId,
-          collateralBalance: 0n,
-          balances: [{ assetId: AssetId('ETH-9'), balance: 20n }],
-        },
-      ],
-      prices: [{ assetId: AssetId('ETH-9'), price: 20n }],
+      positions: [],
+      prices: [],
     })
 
     await repository.add({
@@ -77,26 +68,18 @@ describe(StateUpdateRepository.name, () => {
         factHash: Hash256.fake(),
         timestamp: Timestamp(0),
       },
-      positions: [
-        {
-          publicKey: StarkKey.fake(),
-          positionId,
-          collateralBalance: 0n,
-          balances: [{ assetId: AssetId('BTC-10'), balance: 40n }],
-        },
-      ],
-      prices: [{ assetId: AssetId('BTC-10'), price: 40n }],
+      positions: [],
+      prices: [],
     })
 
-    const position = await repository.getStateUpdateIdByRootHash(rootHash)
-
-    expect(position).toEqual(stateRootId)
+    const result = await repository.findIdByRootHash(rootHash)
+    expect(result).toEqual(1)
   })
 
   it('gets undefined when root hash not found', async () => {
     const rootHash = PedersenHash.fake()
 
-    const position = await repository.getStateUpdateIdByRootHash(rootHash)
+    const position = await repository.findIdByRootHash(rootHash)
 
     expect(position).toEqual(undefined)
   })

--- a/packages/backend/test/peripherals/database/StateUpdateRepository.test.ts
+++ b/packages/backend/test/peripherals/database/StateUpdateRepository.test.ts
@@ -84,61 +84,6 @@ describe(StateUpdateRepository.name, () => {
     expect(position).toEqual(undefined)
   })
 
-  it('gets position by public key', async () => {
-    const positionId = 12345n
-    const publicKey = StarkKey.fake()
-
-    await repository.add({
-      stateUpdate: {
-        id: 1,
-        blockNumber: 1,
-        rootHash: PedersenHash.fake(),
-        factHash: Hash256.fake(),
-        timestamp: Timestamp(0),
-      },
-      positions: [
-        {
-          publicKey,
-          positionId,
-          collateralBalance: 0n,
-          balances: [{ assetId: AssetId('ETH-9'), balance: 20n }],
-        },
-      ],
-      prices: [{ assetId: AssetId('ETH-9'), price: 20n }],
-    })
-
-    await repository.add({
-      stateUpdate: {
-        id: 2,
-        blockNumber: 2,
-        rootHash: PedersenHash.fake(),
-        factHash: Hash256.fake(),
-        timestamp: Timestamp(0),
-      },
-      positions: [
-        {
-          publicKey: StarkKey.fake(),
-          positionId,
-          collateralBalance: 0n,
-          balances: [{ assetId: AssetId('BTC-10'), balance: 40n }],
-        },
-      ],
-      prices: [{ assetId: AssetId('BTC-10'), price: 40n }],
-    })
-
-    const position = await repository.getPositionIdByPublicKey(publicKey)
-
-    expect(position).toEqual(positionId)
-  })
-
-  it('gets undefined when root hash not found', async () => {
-    const publicKey = StarkKey.fake()
-
-    const position = await repository.getPositionIdByPublicKey(publicKey)
-
-    expect(position).toEqual(undefined)
-  })
-
   it('gets all state updates', async () => {
     const stateUpdate: StateUpdateRecord = {
       id: 10_002,

--- a/packages/backend/test/peripherals/database/StateUpdateRepository.test.ts
+++ b/packages/backend/test/peripherals/database/StateUpdateRepository.test.ts
@@ -45,71 +45,6 @@ describe(StateUpdateRepository.name, () => {
     })
   })
 
-  it('gets position by id', async () => {
-    const positionId = 12345n
-
-    await repository.add({
-      stateUpdate: {
-        id: 1,
-        blockNumber: 1,
-        rootHash: PedersenHash.fake(),
-        factHash: Hash256.fake(),
-        timestamp: Timestamp(0),
-      },
-      positions: [
-        {
-          publicKey: StarkKey.fake('1'),
-          positionId,
-          collateralBalance: 0n,
-          balances: [{ assetId: AssetId('ETH-9'), balance: 20n }],
-        },
-      ],
-      prices: [{ assetId: AssetId('ETH-9'), price: 20n }],
-    })
-
-    await repository.add({
-      stateUpdate: {
-        id: 2,
-        blockNumber: 2,
-        rootHash: PedersenHash.fake(),
-        factHash: Hash256.fake(),
-        timestamp: Timestamp(0),
-      },
-      positions: [
-        {
-          publicKey: StarkKey.fake('1'),
-          positionId,
-          collateralBalance: 0n,
-          balances: [{ assetId: AssetId('BTC-10'), balance: 40n }],
-        },
-      ],
-      prices: [{ assetId: AssetId('BTC-10'), price: 40n }],
-    })
-
-    const position = await repository.getPositionHistoryById(positionId)
-
-    expect(position).toEqual([
-      {
-        stateUpdateId: 2,
-        publicKey: StarkKey.fake('1'),
-        positionId,
-        collateralBalance: 0n,
-        balances: [{ assetId: AssetId('BTC-10'), balance: 40n }],
-        prices: [{ assetId: AssetId('BTC-10'), price: 40n }],
-        timestamp: Timestamp(0),
-      },
-      {
-        stateUpdateId: 1,
-        publicKey: StarkKey.fake('1'),
-        positionId,
-        collateralBalance: 0n,
-        balances: [{ assetId: AssetId('ETH-9'), balance: 20n }],
-        prices: [{ assetId: AssetId('ETH-9'), price: 20n }],
-        timestamp: Timestamp(0),
-      },
-    ])
-  })
-
   it('gets state update id by root hash', async () => {
     const stateRootId = 1
     const positionId = 12345n
@@ -236,7 +171,7 @@ describe(StateUpdateRepository.name, () => {
   })
 
   it('gets last state update by block number', async () => {
-    let last = await repository.getLast()
+    let last = await repository.findLast()
 
     expect(last).toEqual(undefined)
 
@@ -262,7 +197,7 @@ describe(StateUpdateRepository.name, () => {
     }
     await repository.add({ stateUpdate, positions: [], prices: [] })
 
-    last = await repository.getLast()
+    last = await repository.findLast()
 
     expect(last).toEqual(stateUpdate)
   })

--- a/packages/backend/test/peripherals/database/SyncStatusRepository.test.ts
+++ b/packages/backend/test/peripherals/database/SyncStatusRepository.test.ts
@@ -6,29 +6,31 @@ import { mock } from '../../mock'
 
 describe(SyncStatusRepository.name, () => {
   it('writes value to store', async () => {
-    const store = mock<KeyValueStore<'lastBlockNumberSynced'>>({
-      set: async () => {},
+    const store = mock<KeyValueStore>({
+      addOrUpdate: async () => 'lastBlockNumberSynced',
     })
     const repository = new SyncStatusRepository(store)
 
     await repository.setLastSynced(20)
-    expect(store.set).toHaveBeenCalledWith(['lastBlockNumberSynced', '20'])
+    expect(store.addOrUpdate).toHaveBeenCalledWith([
+      { key: 'lastBlockNumberSynced', value: '20' },
+    ])
   })
 
   it('reads value from store', async () => {
-    const store = mock<KeyValueStore<'lastBlockNumberSynced'>>({
-      get: async () => '20',
+    const store = mock<KeyValueStore>({
+      findByKey: async () => '20',
     })
     const repository = new SyncStatusRepository(store)
 
     const actual = await repository.getLastSynced()
     expect(actual).toEqual(20)
-    expect(store.get).toHaveBeenCalledWith(['lastBlockNumberSynced'])
+    expect(store.findByKey).toHaveBeenCalledWith(['lastBlockNumberSynced'])
   })
 
   it('returns undefined when store is empty', async () => {
-    const store = mock<KeyValueStore<'lastBlockNumberSynced'>>({
-      get: async () => undefined,
+    const store = mock<KeyValueStore>({
+      findByKey: async () => undefined,
     })
     const repository = new SyncStatusRepository(store)
 
@@ -37,8 +39,8 @@ describe(SyncStatusRepository.name, () => {
   })
 
   it('returns undefined when the store is corrupt', async () => {
-    const store = mock<KeyValueStore<'lastBlockNumberSynced'>>({
-      get: async () => '3 is my favorite number',
+    const store = mock<KeyValueStore>({
+      findByKey: async () => '3 is my favorite number',
     })
     const repository = new SyncStatusRepository(store)
 

--- a/packages/backend/test/peripherals/database/UserRegistrationEventRepository.test.ts
+++ b/packages/backend/test/peripherals/database/UserRegistrationEventRepository.test.ts
@@ -18,7 +18,7 @@ describe(UserRegistrationEventRepository.name, () => {
       starkKey: StarkKey.fake(),
     }
 
-    await repository.add([record])
+    await repository.addMany([record])
 
     const actual = await repository.getAll()
 
@@ -31,7 +31,7 @@ describe(UserRegistrationEventRepository.name, () => {
   })
 
   it('adds 0 records', async () => {
-    await repository.add([])
+    await repository.addMany([])
     expect(await repository.getAll()).toEqual([])
   })
 
@@ -49,14 +49,14 @@ describe(UserRegistrationEventRepository.name, () => {
       },
     ]
 
-    await repository.add(records)
+    await repository.addMany(records)
     const actual = await repository.getAll()
 
     expect(actual).toEqual(records.map((r) => ({ ...r, id: expect.a(Number) })))
   })
 
   it('deletes all records', async () => {
-    await repository.add([
+    await repository.addMany([
       {
         blockNumber: 1,
         ethAddress: EthereumAddress.fake(),
@@ -71,7 +71,7 @@ describe(UserRegistrationEventRepository.name, () => {
   })
 
   it('deletes all records after a block number', async () => {
-    await repository.add([
+    await repository.addMany([
       {
         blockNumber: 1,
         ethAddress: EthereumAddress.fake('1'),
@@ -89,7 +89,7 @@ describe(UserRegistrationEventRepository.name, () => {
       },
     ])
 
-    await repository.deleteAllAfter(2)
+    await repository.deleteAfter(2)
 
     const actual = await repository.getAll()
     expect(actual).toEqual([
@@ -111,7 +111,7 @@ describe(UserRegistrationEventRepository.name, () => {
   it('finds last event for stark key', async () => {
     const starkKey = StarkKey.fake()
     const ethAddress = EthereumAddress.fake()
-    await repository.add([
+    await repository.addMany([
       {
         blockNumber: 1,
         ethAddress: EthereumAddress.ZERO,
@@ -154,7 +154,7 @@ describe(UserRegistrationEventRepository.name, () => {
       event,
     ]
 
-    await repository.add(records)
+    await repository.addMany(records)
     const actual = await repository.findByEthereumAddress(event.ethAddress)
 
     expect(actual).toEqual({ id: expect.a(Number), ...event })

--- a/packages/backend/test/peripherals/database/VerifierEventRepository.test.ts
+++ b/packages/backend/test/peripherals/database/VerifierEventRepository.test.ts
@@ -14,14 +14,14 @@ describe(VerifierEventRepository.name, () => {
   afterEach(() => repository.deleteAll())
 
   it('adds single record and queries it', async () => {
-    const record: VerifierEventRecord = {
+    const record: Omit<VerifierEventRecord, 'id'> = {
       name: 'ImplementationAdded',
       implementation: '0x0000000000000000000000000000000000000000',
       initializer: '0x0000000000000000000000000000000000000000',
       blockNumber: 1,
     }
 
-    await repository.add([record])
+    await repository.addMany([record])
 
     const actual = await repository.getAll()
 
@@ -34,12 +34,12 @@ describe(VerifierEventRepository.name, () => {
   })
 
   it('adds 0 records', async () => {
-    await repository.add([])
+    await repository.addMany([])
     expect(await repository.getAll()).toEqual([])
   })
 
   it('adds multiple records and queries them', async () => {
-    const records: VerifierEventRecord[] = [
+    const records: Omit<VerifierEventRecord, 'id'>[] = [
       {
         name: 'ImplementationAdded',
         implementation: '0x0000000000000000000000000000000000000000',
@@ -59,14 +59,14 @@ describe(VerifierEventRepository.name, () => {
       },
     ]
 
-    await repository.add(records)
+    await repository.addMany(records)
     const actual = await repository.getAll()
 
     expect(actual).toEqual(records.map((r) => ({ ...r, id: expect.a(Number) })))
   })
 
   it('deletes all records', async () => {
-    await repository.add([
+    await repository.addMany([
       {
         name: 'ImplementationAdded',
         initializer: '0x0000000000000000000000000000000000000001',
@@ -87,7 +87,7 @@ describe(VerifierEventRepository.name, () => {
   })
 
   it('deletes all records after a block number', async () => {
-    await repository.add([
+    await repository.addMany([
       {
         name: 'Upgraded',
         implementation: '0x0000000000000000000000000000000000000001',
@@ -105,7 +105,7 @@ describe(VerifierEventRepository.name, () => {
       },
     ])
 
-    await repository.deleteAllAfter(2)
+    await repository.deleteAfter(2)
 
     const actual = await repository.getAll()
     expect(actual).toEqual([

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,11 +1913,6 @@ concat-stream@^1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-conditional-type-checks@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/conditional-type-checks/-/conditional-type-checks-1.0.5.tgz#310ecd13c46c3963fbe9a2f8f93511d88cdcc973"
-  integrity sha512-DkfkvmjXVe4ye4llJ1JADtO3dNvqqcQM08cA9BhNt9Oe8pyRW8X1CZyBg9Qst05bDV9BJM01KLmnFh78NcJgNg==
-
 configstore@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-5.0.1.tgz#d365021b5df4b98cdd187d6a3b0e3f6a7cc5ed96"


### PR DESCRIPTION
This PR does the following things:
1. Unify naming across repositories
2. Enforce consistent logging
3. Remove the type argument from KeyValueStore
4. Extract PositionRepository from StateUpdateRepository