### PR TITLE
Cancel forced trade offer (Backend)

### DIFF
--- a/packages/backend/src/api/controllers/ForcedTradeOfferController.ts
+++ b/packages/backend/src/api/controllers/ForcedTradeOfferController.ts
@@ -95,7 +95,13 @@ export class ForcedTradeOfferController {
     if (offer.accepted) {
       return {
         type: 'bad request',
-        content: 'Offer already accepted by a user.',
+        content: 'Offer already accepted.',
+      }
+    }
+    if (offer.cancelledAt) {
+      return {
+        type: 'bad request',
+        content: 'Offer already cancelled.',
       }
     }
     const requestValid = validateAccept(

--- a/packages/backend/src/api/controllers/ForcedTradeOfferController.ts
+++ b/packages/backend/src/api/controllers/ForcedTradeOfferController.ts
@@ -234,7 +234,7 @@ function validateBalance(
   return false
 }
 
-function validateAddress(
+function validateSignature(
   digest: string,
   signature: string,
   address: EthereumAddress
@@ -253,7 +253,7 @@ function validateCancelRequest(
   signature: string
 ): boolean {
   const request = getCancelRequest(offerId)
-  return validateAddress(hashMessage(request), signature, address)
+  return validateSignature(hashMessage(request), signature, address)
 }
 
 export function validateInitialSignature(
@@ -262,7 +262,7 @@ export function validateInitialSignature(
   address: EthereumAddress
 ) {
   const request = stringifyInitialOffer(offer)
-  return validateAddress(hashMessage(request), signature, address)
+  return validateSignature(hashMessage(request), signature, address)
 }
 
 export function validateAcceptedSignature(

--- a/packages/backend/src/api/controllers/ForcedTradeOfferController.ts
+++ b/packages/backend/src/api/controllers/ForcedTradeOfferController.ts
@@ -234,14 +234,26 @@ function validateBalance(
   return false
 }
 
+function validateAddress(
+  digest: string,
+  signature: string,
+  address: EthereumAddress
+): boolean {
+  try {
+    const signer = recoverAddress(digest, signature)
+    return signer === address.toString()
+  } catch (error) {
+    return false
+  }
+}
+
 function validateCancelRequest(
   offerId: ForcedTradeOfferRecord['id'],
   address: EthereumAddress,
   signature: string
 ): boolean {
   const request = getCancelRequest(offerId)
-  const signer = recoverAddress(hashMessage(request), signature)
-  return signer === address.toString()
+  return validateAddress(hashMessage(request), signature, address)
 }
 
 export function validateInitialSignature(
@@ -249,9 +261,8 @@ export function validateInitialSignature(
   signature: string,
   address: EthereumAddress
 ) {
-  const stringOffer = stringifyInitialOffer(offer)
-  const signer = recoverAddress(hashMessage(stringOffer), signature)
-  return signer === address.toString()
+  const request = stringifyInitialOffer(offer)
+  return validateAddress(hashMessage(request), signature, address)
 }
 
 export function validateAcceptedSignature(

--- a/packages/backend/src/api/controllers/ForcedTradeOfferController.ts
+++ b/packages/backend/src/api/controllers/ForcedTradeOfferController.ts
@@ -270,11 +270,6 @@ export function validateAcceptedSignature(
   accepted: Omit<Accepted, 'at'>,
   address: EthereumAddress
 ): boolean {
-  try {
-    const digest = digestAcceptedOfferParams(offer, accepted)
-    const signer = recoverAddress(digest, accepted.signature)
-    return signer === address.toString()
-  } catch (e) {
-    return false
-  }
+  const digest = digestAcceptedOfferParams(offer, accepted)
+  return validateSignature(digest, accepted.signature, address)
 }

--- a/packages/backend/src/api/controllers/ForcedTradeOfferController.ts
+++ b/packages/backend/src/api/controllers/ForcedTradeOfferController.ts
@@ -1,8 +1,8 @@
 import { renderForcedTradeOffersIndexPage } from '@explorer/frontend'
 import {
-  digestAcceptedOfferParams,
+  getAcceptRequest,
   getCancelRequest,
-  stringifyInitialOffer,
+  getCreateRequest,
 } from '@explorer/shared'
 import { EthereumAddress, Timestamp } from '@explorer/types'
 import { hashMessage, recoverAddress } from 'ethers/lib/utils'
@@ -247,13 +247,22 @@ function validateSignature(
   }
 }
 
+function validatePersonalSignature(
+  request: string,
+  signature: string,
+  address: EthereumAddress
+): boolean {
+  const toSign = hashMessage(request)
+  return validateSignature(toSign, signature, address)
+}
+
 function validateCancelRequest(
   offerId: ForcedTradeOfferRecord['id'],
   address: EthereumAddress,
   signature: string
 ): boolean {
   const request = getCancelRequest(offerId)
-  return validateSignature(hashMessage(request), signature, address)
+  return validatePersonalSignature(request, signature, address)
 }
 
 export function validateInitialSignature(
@@ -261,8 +270,8 @@ export function validateInitialSignature(
   signature: string,
   address: EthereumAddress
 ) {
-  const request = stringifyInitialOffer(offer)
-  return validateSignature(hashMessage(request), signature, address)
+  const request = getCreateRequest(offer)
+  return validatePersonalSignature(request, signature, address)
 }
 
 export function validateAcceptedSignature(
@@ -270,6 +279,6 @@ export function validateAcceptedSignature(
   accepted: Omit<Accepted, 'at'>,
   address: EthereumAddress
 ): boolean {
-  const digest = digestAcceptedOfferParams(offer, accepted)
+  const digest = getAcceptRequest(offer, accepted)
   return validateSignature(digest, accepted.signature, address)
 }

--- a/packages/backend/src/api/controllers/utils/ForcedTradeOfferValidators.ts
+++ b/packages/backend/src/api/controllers/utils/ForcedTradeOfferValidators.ts
@@ -1,0 +1,117 @@
+import {
+  getAcceptRequest,
+  getCancelRequest,
+  getCreateRequest,
+} from '@explorer/shared'
+import { EthereumAddress } from '@explorer/types'
+import { hashMessage, recoverAddress } from 'ethers/lib/utils'
+
+import {
+  Accepted,
+  ForcedTradeOfferRecord,
+} from '../../../peripherals/database/ForcedTradeOfferRepository'
+import { PositionRecord } from '../../../peripherals/database/PositionRepository'
+
+export function validateCreate(
+  offer: Omit<ForcedTradeOfferRecord, 'createdAt' | 'id'>,
+  position: PositionRecord,
+  signature: string,
+  ethAddressA: EthereumAddress
+) {
+  const userIsBuyingSynthetic = offer.aIsBuyingSynthetic
+
+  if (!validateBalance(offer, position, userIsBuyingSynthetic)) {
+    return false
+  }
+
+  return validateCreateSignature(offer, signature, ethAddressA)
+}
+
+export function validateAccept(
+  offer: ForcedTradeOfferRecord,
+  accepted: Omit<Accepted, 'at'>,
+  position: PositionRecord,
+  ethAddressB: EthereumAddress
+) {
+  const userIsBuyingSynthetic = !offer.aIsBuyingSynthetic
+
+  if (!validateBalance(offer, position, userIsBuyingSynthetic)) {
+    return false
+  }
+
+  return validateAcceptSignature(offer, accepted, ethAddressB)
+}
+
+export function validateCancel(
+  offerId: ForcedTradeOfferRecord['id'],
+  address: EthereumAddress,
+  signature: string
+): boolean {
+  const request = getCancelRequest(offerId)
+  return validatePersonalSignature(request, signature, address)
+}
+
+function validateBalance(
+  offer: Omit<ForcedTradeOfferRecord, 'createdAt' | 'id'>,
+  position: PositionRecord,
+  userIsBuyingSynthetic: boolean
+) {
+  const { amountCollateral, amountSynthetic, syntheticAssetId } = offer
+
+  const { collateralBalance } = position
+
+  if (userIsBuyingSynthetic && amountCollateral <= collateralBalance) {
+    return true
+  }
+
+  if (!userIsBuyingSynthetic) {
+    const balanceSynthetic = position.balances.find(
+      (balance) => balance.assetId === syntheticAssetId
+    )?.balance
+    if (balanceSynthetic && balanceSynthetic >= amountSynthetic) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function validateSignature(
+  digest: string,
+  signature: string,
+  address: EthereumAddress
+): boolean {
+  try {
+    const signer = recoverAddress(digest, signature)
+    return signer === address.toString()
+  } catch (error) {
+    return false
+  }
+}
+
+function validatePersonalSignature(
+  request: string,
+  signature: string,
+  address: EthereumAddress
+): boolean {
+  const toSign = hashMessage(request)
+  return validateSignature(toSign, signature, address)
+}
+
+export function validateCreateSignature(
+  offer: Omit<ForcedTradeOfferRecord, 'createdAt' | 'id'>,
+  signature: string,
+  address: EthereumAddress
+) {
+  const request = getCreateRequest(offer)
+  return validatePersonalSignature(request, signature, address)
+}
+
+export function validateAcceptSignature(
+  offer: Omit<ForcedTradeOfferRecord, 'createdAt' | 'id'>,
+  accepted: Omit<Accepted, 'at' | 'premiumCost'>,
+  address: EthereumAddress
+): boolean {
+  const request = getAcceptRequest(offer, accepted)
+  return validateSignature(request, accepted.signature, address)
+}

--- a/packages/backend/src/api/routers/ForcedTradeOfferRouter.ts
+++ b/packages/backend/src/api/routers/ForcedTradeOfferRouter.ts
@@ -73,5 +73,25 @@ export function createForcedTradeOfferRouter(
     )
   )
 
+  router.post(
+    '/forced/offers/:offerId/cancel',
+    bodyParser(),
+    withTypedContext(
+      z.object({
+        params: z.object({
+          offerId: stringAsInt(),
+          signature: z.string(),
+        }),
+      }),
+      async (ctx) => {
+        const result = await offerController.cancelOffer(
+          ctx.params.offerId,
+          ctx.params.signature
+        )
+        applyControllerResult(ctx, result)
+      }
+    )
+  )
+
   return router
 }

--- a/packages/backend/src/api/routers/ForcedTradeOfferRouter.ts
+++ b/packages/backend/src/api/routers/ForcedTradeOfferRouter.ts
@@ -80,13 +80,17 @@ export function createForcedTradeOfferRouter(
       z.object({
         params: z.object({
           offerId: stringAsInt(),
-          signature: z.string(),
+        }),
+        request: z.object({
+          body: z.object({
+            signature: z.string(),
+          }),
         }),
       }),
       async (ctx) => {
         const result = await offerController.cancelOffer(
           ctx.params.offerId,
-          ctx.params.signature
+          ctx.request.body.signature
         )
         applyControllerResult(ctx, result)
       }

--- a/packages/backend/src/peripherals/database/ForcedTradeOfferRepository.ts
+++ b/packages/backend/src/peripherals/database/ForcedTradeOfferRepository.ts
@@ -3,7 +3,6 @@ import { Knex } from 'knex'
 import { ForcedTradeOfferRow as Row } from 'knex/types/tables'
 
 import { Logger } from '../../tools/Logger'
-import { Nullable } from '../../utils/Nullable'
 import { BaseRepository } from './BaseRepository'
 
 export interface Accepted {
@@ -27,7 +26,7 @@ interface Record {
   amountSynthetic: bigint
   aIsBuyingSynthetic: boolean
   accepted?: Accepted
-  cancelledAt?: Nullable<Timestamp>
+  cancelledAt?: Timestamp
 }
 export { type Record as ForcedTradeOfferRecord }
 
@@ -82,7 +81,7 @@ function toRecord(row: Row): Record {
     amountSynthetic: row.amount_synthetic,
     aIsBuyingSynthetic: row.a_is_buying_synthetic,
     accepted: undefined,
-    cancelledAt: row.cancelled_at ? Timestamp(row.cancelled_at) : null,
+    cancelledAt: row.cancelled_at ? Timestamp(row.cancelled_at) : undefined,
   }
   if (
     row.accepted_at !== null &&

--- a/packages/backend/src/peripherals/database/ForcedTradeOfferRepository.ts
+++ b/packages/backend/src/peripherals/database/ForcedTradeOfferRepository.ts
@@ -57,7 +57,7 @@ function toRowCandidate(record: RecordCandidate): RowCandidate {
     signature: orNull(record.accepted?.signature),
     transaction_hash: orNull(record.accepted?.transactionHash?.toString()),
     cancelled_at:
-      record.cancelledAt !== undefined && record.cancelledAt !== null
+      record.cancelledAt !== undefined
         ? BigInt(record.cancelledAt.toString())
         : null,
   }

--- a/packages/backend/src/peripherals/database/ForcedTradeOfferRepository.ts
+++ b/packages/backend/src/peripherals/database/ForcedTradeOfferRepository.ts
@@ -3,6 +3,7 @@ import { Knex } from 'knex'
 import { ForcedTradeOfferRow as Row } from 'knex/types/tables'
 
 import { Logger } from '../../tools/Logger'
+import { Nullable } from '../../utils/Nullable'
 import { BaseRepository } from './BaseRepository'
 
 export interface Accepted {
@@ -26,6 +27,7 @@ interface Record {
   amountSynthetic: bigint
   aIsBuyingSynthetic: boolean
   accepted?: Accepted
+  cancelledAt?: Nullable<Timestamp>
 }
 export { type Record as ForcedTradeOfferRecord }
 
@@ -55,6 +57,10 @@ function toRowCandidate(record: RecordCandidate): RowCandidate {
     premium_cost: orNull(record.accepted?.premiumCost),
     signature: orNull(record.accepted?.signature),
     transaction_hash: orNull(record.accepted?.transactionHash?.toString()),
+    cancelled_at:
+      record.cancelledAt !== undefined && record.cancelledAt !== null
+        ? BigInt(record.cancelledAt.toString())
+        : null,
   }
 }
 
@@ -76,6 +82,7 @@ function toRecord(row: Row): Record {
     amountSynthetic: row.amount_synthetic,
     aIsBuyingSynthetic: row.a_is_buying_synthetic,
     accepted: undefined,
+    cancelledAt: row.cancelled_at ? Timestamp(row.cancelled_at) : null,
   }
   if (
     row.accepted_at !== null &&

--- a/packages/backend/src/peripherals/database/migrations/018_forced_trade_offers_cancelled.ts
+++ b/packages/backend/src/peripherals/database/migrations/018_forced_trade_offers_cancelled.ts
@@ -1,0 +1,26 @@
+/*
+                      ====== IMPORTANT NOTICE ======
+
+DO NOT EDIT OR RENAME THIS FILE
+
+This is a migration file. Once created the file should not be renamed or edited,
+because migrations are only run once on the production server. 
+
+If you find that something was incorrectly set up in the `up` function you
+should create a new migration file that fixes the issue.
+
+*/
+
+import { Knex } from 'knex'
+
+export async function up(knex: Knex) {
+  await knex.schema.alterTable('forced_trade_offers', (table) => {
+    table.bigInteger('cancelled_at')
+  })
+}
+
+export async function down(knex: Knex) {
+  await knex.schema.alterTable('forced_trade_offers', (table) => {
+    table.dropColumn('cancelled_at')
+  })
+}

--- a/packages/backend/src/peripherals/database/types.ts
+++ b/packages/backend/src/peripherals/database/types.ts
@@ -144,6 +144,7 @@ declare module 'knex/types/tables' {
     premium_cost: Nullable<boolean>
     signature: Nullable<string>
     transaction_hash: Nullable<string>
+    cancelled_at: Nullable<bigint>
   }
 
   interface Tables {

--- a/packages/backend/test/api/controllers/ForcedTradeOfferController.test.ts
+++ b/packages/backend/test/api/controllers/ForcedTradeOfferController.test.ts
@@ -211,6 +211,57 @@ describe(ForcedTradeOfferController.name, async () => {
       })
     })
 
+    it('blocks accepted offer', async () => {
+      const controller = new ForcedTradeOfferController(
+        mock<ForcedTradeOfferRepository>({
+          findById: async () => ({
+            id: 1,
+            createdAt: Timestamp(Date.now() - 2000),
+            ...tradeMock.offer,
+            accepted: {
+              ...tradeMock.accepted,
+              at: Timestamp(Date.now() - 1000),
+            },
+          }),
+        }),
+        mock<PositionRepository>({
+          findById: async () => positionA,
+        }),
+        mock<UserRegistrationEventRepository>({
+          findByStarkKey: async () => userA,
+        })
+      )
+
+      expect(await controller.acceptOffer(1, tradeMock.accepted)).toEqual({
+        type: 'bad request',
+        content: 'Offer already accepted.',
+      })
+    })
+
+    it('blocks cancelled offer', async () => {
+      const controller = new ForcedTradeOfferController(
+        mock<ForcedTradeOfferRepository>({
+          findById: async () => ({
+            id: 1,
+            createdAt: Timestamp(Date.now() - 2000),
+            ...tradeMock.offer,
+            cancelledAt: Timestamp(Date.now() - 1000),
+          }),
+        }),
+        mock<PositionRepository>({
+          findById: async () => positionA,
+        }),
+        mock<UserRegistrationEventRepository>({
+          findByStarkKey: async () => userA,
+        })
+      )
+
+      expect(await controller.acceptOffer(1, tradeMock.accepted)).toEqual({
+        type: 'bad request',
+        content: 'Offer already cancelled.',
+      })
+    })
+
     it('blocks invalid balance', async () => {
       const id = 1
       const controller = new ForcedTradeOfferController(

--- a/packages/backend/test/api/controllers/ForcedTradeOfferController.test.ts
+++ b/packages/backend/test/api/controllers/ForcedTradeOfferController.test.ts
@@ -8,25 +8,25 @@ import { ForcedTradeOfferRepository } from '../../../src/peripherals/database/Fo
 import { PositionRepository } from '../../../src/peripherals/database/PositionRepository'
 import { UserRegistrationEventRepository } from '../../../src/peripherals/database/UserRegistrationEventRepository'
 import { mock } from '../../mock'
-import { accepted, addressB, offer } from './utils/ForcedTradeOfferMockData'
+import * as tradeMock from './utils/ForcedTradeOfferMockData'
 
 describe(ForcedTradeOfferController.name, async () => {
   const stateUpdateId = 1
   const positionA = {
-    positionId: offer.positionIdA,
-    publicKey: offer.starkKeyA,
-    collateralBalance: offer.amountCollateral,
+    positionId: tradeMock.offer.positionIdA,
+    publicKey: tradeMock.offer.starkKeyA,
+    collateralBalance: tradeMock.offer.amountCollateral,
     balances: [],
     stateUpdateId,
   }
   const positionB = {
-    publicKey: accepted.starkKeyB,
-    positionId: accepted.positionIdB,
+    publicKey: tradeMock.accepted.starkKeyB,
+    positionId: tradeMock.accepted.positionIdB,
     collateralBalance: 0n,
     balances: [
       {
-        assetId: offer.syntheticAssetId,
-        balance: offer.amountSynthetic,
+        assetId: tradeMock.offer.syntheticAssetId,
+        balance: tradeMock.offer.amountSynthetic,
       },
     ],
     stateUpdateId,
@@ -36,14 +36,14 @@ describe(ForcedTradeOfferController.name, async () => {
   const userA = {
     id: 1,
     blockNumber: 1,
-    starkKey: offer.starkKeyA,
+    starkKey: tradeMock.offer.starkKeyA,
     ethAddress: addressA,
   }
   const userB = {
     id: 2,
     blockNumber: 1,
-    starkKey: accepted.starkKeyB,
-    ethAddress: addressB,
+    starkKey: tradeMock.accepted.starkKeyB,
+    ethAddress: tradeMock.addressB,
   }
   const invalidSignature = '0x12345'
 
@@ -65,7 +65,9 @@ describe(ForcedTradeOfferController.name, async () => {
         userRegistrationEventRepository
       )
 
-      expect(await controller.postOffer(offer, invalidSignature)).toEqual({
+      expect(
+        await controller.postOffer(tradeMock.offer, invalidSignature)
+      ).toEqual({
         type: 'bad request',
         content: 'Your offer is invalid.',
       })
@@ -82,7 +84,9 @@ describe(ForcedTradeOfferController.name, async () => {
         })
       )
 
-      expect(await controller.postOffer(offer, invalidSignature)).toEqual({
+      expect(
+        await controller.postOffer(tradeMock.offer, invalidSignature)
+      ).toEqual({
         type: 'not found',
         content: 'Position does not exist.',
       })
@@ -99,7 +103,9 @@ describe(ForcedTradeOfferController.name, async () => {
         })
       )
 
-      expect(await controller.postOffer(offer, invalidSignature)).toEqual({
+      expect(
+        await controller.postOffer(tradeMock.offer, invalidSignature)
+      ).toEqual({
         type: 'not found',
         content: 'Position does not exist.',
       })
@@ -116,7 +122,9 @@ describe(ForcedTradeOfferController.name, async () => {
         })
       )
 
-      expect(await controller.postOffer(offer, invalidSignature)).toEqual({
+      expect(
+        await controller.postOffer(tradeMock.offer, invalidSignature)
+      ).toEqual({
         type: 'bad request',
         content: 'Your offer is invalid.',
       })
@@ -140,9 +148,9 @@ describe(ForcedTradeOfferController.name, async () => {
         userRegistrationEventRepository
       )
 
-      const request = getCreateRequest(offer)
+      const request = getCreateRequest(tradeMock.offer)
       const signature = await wallet.signMessage(request)
-      expect(await controller.postOffer(offer, signature)).toEqual({
+      expect(await controller.postOffer(tradeMock.offer, signature)).toEqual({
         type: 'created',
         content: { id },
       })
@@ -161,7 +169,7 @@ describe(ForcedTradeOfferController.name, async () => {
         })
       )
 
-      expect(await controller.acceptOffer(1, accepted)).toEqual({
+      expect(await controller.acceptOffer(1, tradeMock.accepted)).toEqual({
         type: 'not found',
         content: 'Position does not exist.',
       })
@@ -178,7 +186,7 @@ describe(ForcedTradeOfferController.name, async () => {
         })
       )
 
-      expect(await controller.acceptOffer(1, accepted)).toEqual({
+      expect(await controller.acceptOffer(1, tradeMock.accepted)).toEqual({
         type: 'not found',
         content: 'Position does not exist.',
       })
@@ -197,7 +205,7 @@ describe(ForcedTradeOfferController.name, async () => {
         })
       )
 
-      expect(await controller.acceptOffer(1, accepted)).toEqual({
+      expect(await controller.acceptOffer(1, tradeMock.accepted)).toEqual({
         type: 'not found',
         content: 'Offer does not exist.',
       })
@@ -209,7 +217,7 @@ describe(ForcedTradeOfferController.name, async () => {
         mock<ForcedTradeOfferRepository>({
           add: async () => id,
           findById: async () => ({
-            ...offer,
+            ...tradeMock.offer,
             id,
             createdAt: Timestamp(Date.now()),
           }),
@@ -236,7 +244,7 @@ describe(ForcedTradeOfferController.name, async () => {
         })
       )
 
-      expect(await controller.acceptOffer(id, accepted)).toEqual({
+      expect(await controller.acceptOffer(id, tradeMock.accepted)).toEqual({
         type: 'bad request',
         content: 'Your offer is invalid.',
       })
@@ -250,7 +258,7 @@ describe(ForcedTradeOfferController.name, async () => {
           findById: async () => ({
             id,
             createdAt: Timestamp(Date.now()),
-            ...offer,
+            ...tradeMock.offer,
           }),
           save: async () => true,
         }),
@@ -276,7 +284,7 @@ describe(ForcedTradeOfferController.name, async () => {
         })
       )
 
-      expect(await controller.acceptOffer(id, accepted)).toEqual({
+      expect(await controller.acceptOffer(id, tradeMock.accepted)).toEqual({
         type: 'success',
         content: 'Accept offer was submitted.',
       })
@@ -285,19 +293,17 @@ describe(ForcedTradeOfferController.name, async () => {
 
   describe(ForcedTradeOfferController.prototype.cancelOffer.name, () => {
     const id = 1
-    const wallet = Wallet.createRandom()
-    const address = EthereumAddress(wallet.address)
     const request = getCancelRequest(id)
     const initial = {
       id,
-      ...offer,
+      ...tradeMock.offer,
       createdAt: Timestamp(Date.now() - 1000),
       accepted: undefined,
     }
     const accepted = {
       ...initial,
       accepted: {
-        ...accept,
+        ...tradeMock.accepted,
         at: Timestamp(Date.now() - 500),
       },
     }
@@ -387,7 +393,7 @@ describe(ForcedTradeOfferController.name, async () => {
         })
       )
 
-      const signature = await wallet.signMessage(request)
+      const signature = await wallet.signMessage(request + 'tampered')
       expect(await controller.cancelOffer(id, signature)).toEqual({
         type: 'bad request',
         content: 'Signature does not match.',
@@ -404,7 +410,7 @@ describe(ForcedTradeOfferController.name, async () => {
         mock<UserRegistrationEventRepository>({
           findByStarkKey: async () => ({
             ...userA,
-            ethAddress: address,
+            ethAddress: addressA,
           }),
         })
       )

--- a/packages/backend/test/api/controllers/utils/ForcedTradeOfferMockData.ts
+++ b/packages/backend/test/api/controllers/utils/ForcedTradeOfferMockData.ts
@@ -1,0 +1,30 @@
+import { AssetId, EthereumAddress, StarkKey } from '@explorer/types'
+
+// Taken from: https://etherscan.io/tx/0x9b2dce5538d0c8c08511c9383be9b67da6f952b367baff0c8bdb5f66c9395634
+
+export const addressB = EthereumAddress(
+  '0xCE9a3e51B905997F1D098345a92B6c749A1f72B9'
+)
+
+export const offer = {
+  starkKeyA: StarkKey(
+    '05733b2b5e71223285e7966386a4e81d3c55480782af122227cf7d1b0b08c32e'
+  ),
+  positionIdA: BigInt('0x205'),
+  syntheticAssetId: AssetId('AAVE-8'),
+  amountCollateral: BigInt('0x684ee1800'),
+  amountSynthetic: BigInt('0xf4240'),
+  aIsBuyingSynthetic: true,
+}
+
+export const accepted = {
+  starkKeyB: StarkKey(
+    '069913f789acdd07ff1aff8aa5dcf3d4935cf1d8b29d0f41839cd1be52dc4a41'
+  ),
+  positionIdB: BigInt('0x2ce'),
+  submissionExpirationTime: 3456000000000n,
+  nonce: BigInt(38404830),
+  premiumCost: true,
+  signature:
+    '0x1bb089c2686c65d8d2e5800761b2826e0fc1f68f7e228fc161384958222bbc271458f40ed77507d59ca77c56204b0134b429eaface39b196d1f07e917a14c7641b',
+}

--- a/packages/backend/test/api/controllers/utils/ForcedTradeOffersValidators.test.ts
+++ b/packages/backend/test/api/controllers/utils/ForcedTradeOffersValidators.test.ts
@@ -1,0 +1,37 @@
+import { getCreateRequest } from '@explorer/shared'
+import { AssetId, EthereumAddress, StarkKey } from '@explorer/types'
+import { expect } from 'earljs'
+import { Wallet } from 'ethers'
+
+import {
+  validateAcceptSignature,
+  validateCreateSignature,
+} from '../../../../src/api/controllers/utils/ForcedTradeOfferValidators'
+import { fakeBigInt } from '../../../fakes'
+import { accepted, addressB, offer } from './ForcedTradeOfferMockData'
+
+// Mock data taken from real transaction: https://etherscan.io/tx/0x9b2dce5538d0c8c08511c9383be9b67da6f952b367baff0c8bdb5f66c9395634
+
+describe(validateCreateSignature.name, () => {
+  it('accepts correct input', async () => {
+    const offer = {
+      aIsBuyingSynthetic: true,
+      amountCollateral: fakeBigInt(),
+      amountSynthetic: fakeBigInt(),
+      positionIdA: fakeBigInt(),
+      starkKeyA: StarkKey.fake(),
+      syntheticAssetId: AssetId('BTC-10'),
+    }
+    const wallet = Wallet.createRandom()
+    const address = EthereumAddress(wallet.address)
+    const request = getCreateRequest(offer)
+    const signature = await wallet.signMessage(request)
+    expect(validateCreateSignature(offer, signature, address)).toBeTruthy()
+  })
+})
+
+describe(validateAcceptSignature.name, () => {
+  it('accepts correct input', async () => {
+    expect(validateAcceptSignature(offer, accepted, addressB)).toBeTruthy()
+  })
+})

--- a/packages/backend/test/api/routers/ForcedTradeOfferRouter.test.ts
+++ b/packages/backend/test/api/routers/ForcedTradeOfferRouter.test.ts
@@ -31,6 +31,7 @@ describe('OfferRouter', () => {
             content: 'Accept offer was submitted.',
           }
         : { type: 'not found', content: 'Offer does not exist.' },
+    cancelOffer: async () => ({ type: 'success', content: 'Offer cancelled.' }),
   })
   const router = createForcedTradeOfferRouter(offerController)
   const server = createTestApiServer([router])
@@ -72,6 +73,26 @@ describe('OfferRouter', () => {
             '0x1bb089c2686c65d8d2e5800761b2826e0fc1f68f7e228fc161384958222bbc271458f40ed77507d59ca77c56204b0134b429eaface39b196d1f07e917a14c7641b',
         })
         .expect(404)
+    })
+  })
+
+  describe('/forced/offers/:initialOfferId', () => {
+    it('returns success', async () => {
+      await server
+        .post('/forced/offers/1/cancel')
+        .send({
+          signature:
+            '0x1bb089c2686c65d8d2e5800761b2826e0fc1f68f7e228fc161384958222bbc271458f40ed77507d59ca77c56204b0134b429eaface39b196d1f07e917a14c7641b',
+        })
+        .expect(200)
+    })
+    it('returns bad request for invalid input', async () => {
+      await server
+        .post('/forced/offers/1/cancel')
+        .send({
+          signature: 123,
+        })
+        .expect(400)
     })
   })
 })

--- a/packages/backend/test/api/routers/ForcedTradeOfferRouter.test.ts
+++ b/packages/backend/test/api/routers/ForcedTradeOfferRouter.test.ts
@@ -2,92 +2,89 @@ import { AssetId, StarkKey } from '@explorer/types'
 
 import { ForcedTradeOfferController } from '../../../src/api/controllers/ForcedTradeOfferController'
 import { createForcedTradeOfferRouter } from '../../../src/api/routers/ForcedTradeOfferRouter'
+import { fakeBigInt, fakeBoolean, fakeInt } from '../../fakes'
 import { mock } from '../../mock'
 import { createTestApiServer } from '../TestApiServer'
 
-const starkKeyA = StarkKey(
-  '05733b2b5e71223285e7966386a4e81d3c55480782af122227cf7d1b0b08c32e'
-)
-const starkKeyB = StarkKey(
-  '069913f789acdd07ff1aff8aa5dcf3d4935cf1d8b29d0f41839cd1be52dc4a41'
-)
-
-const validInitialOffer = {
-  starkKeyA: starkKeyA,
-  positionIdA: 0n.toString(),
-  syntheticAssetId: AssetId('ETH-9').toString(),
-  amountCollateral: 2000n.toString(),
-  amountSynthetic: 1n.toString(),
-  aIsBuyingSynthetic: true,
+const signature = '0x12345'
+const initialData = {
+  offer: {
+    starkKeyA: StarkKey.fake(),
+    positionIdA: 0n.toString(),
+    syntheticAssetId: AssetId('ETH-9').toString(),
+    amountCollateral: 2000n.toString(),
+    amountSynthetic: 1n.toString(),
+    aIsBuyingSynthetic: true,
+  },
+  signature,
+}
+const acceptedData = {
+  starkKeyB: StarkKey.fake(),
+  positionIdB: fakeBigInt().toString(),
+  submissionExpirationTime: fakeInt().toString(),
+  nonce: fakeBigInt().toString(),
+  premiumCost: fakeBoolean(),
+  signature,
 }
 
-describe('OfferRouter', () => {
-  const offerController = mock<ForcedTradeOfferController>({
-    postOffer: async () => ({ type: 'created', content: { id: 1 } }),
-    acceptOffer: async (id) =>
-      id === 1
-        ? {
-            type: 'success',
-            content: 'Accept offer was submitted.',
-          }
-        : { type: 'not found', content: 'Offer does not exist.' },
-    cancelOffer: async () => ({ type: 'success', content: 'Offer cancelled.' }),
-  })
+function createServer(overrides?: Partial<ForcedTradeOfferController>) {
+  const offerController = mock<ForcedTradeOfferController>(overrides)
   const router = createForcedTradeOfferRouter(offerController)
-  const server = createTestApiServer([router])
+  return createTestApiServer([router])
+}
 
+describe('ForcedTradeOfferRouter', () => {
   describe('/forced/offers', () => {
     it('returns created', async () => {
-      await server
+      const id = 1
+      await createServer({
+        postOffer: async () => ({ type: 'created', content: { id } }),
+      })
         .post('/forced/offers')
-        .send({ offer: validInitialOffer, signature: '0x' })
-        .expect(201, { id: 1 })
+        .send(initialData)
+        .expect(201, { id })
     })
   })
 
   describe('/forced/offers/:initialOfferId', () => {
     it('returns success', async () => {
-      await server
-        .put(`/forced/offers/1`)
-        .send({
-          starkKeyB: starkKeyB.toString(),
-          positionIdB: 718n.toString(),
-          submissionExpirationTime: '3456000000000',
-          nonce: 38404830n.toString(),
-          premiumCost: true,
-          signature:
-            '0x1bb089c2686c65d8d2e5800761b2826e0fc1f68f7e228fc161384958222bbc271458f40ed77507d59ca77c56204b0134b429eaface39b196d1f07e917a14c7641b',
-        })
+      await createServer({
+        acceptOffer: async () => ({
+          type: 'success',
+          content: 'Accept offer was submitted.',
+        }),
+      })
+        .put('/forced/offers/1')
+        .send(acceptedData)
         .expect(200)
     })
-    it('returns not found when offer id invalid', async () => {
-      await server
-        .put(`/forced/offers/2`)
-        .send({
-          starkKeyB: starkKeyB.toString(),
-          positionIdB: 718n.toString(),
-          submissionExpirationTime: '3456000000000',
-          nonce: 38404830n.toString(),
-          premiumCost: true,
-          signature:
-            '0x1bb089c2686c65d8d2e5800761b2826e0fc1f68f7e228fc161384958222bbc271458f40ed77507d59ca77c56204b0134b429eaface39b196d1f07e917a14c7641b',
-        })
+    it('returns not found when offer not found', async () => {
+      await createServer({
+        acceptOffer: async () => ({
+          type: 'not found',
+          content: 'Offer does not exist.',
+        }),
+      })
+        .put('/forced/offers/1')
+        .send(acceptedData)
         .expect(404)
     })
   })
 
   describe('/forced/offers/:initialOfferId', () => {
     it('returns success', async () => {
-      await server
+      await createServer({
+        cancelOffer: async () => ({
+          type: 'success',
+          content: 'Offer cancelled.',
+        }),
+      })
         .post('/forced/offers/1/cancel')
-        .send({
-          signature:
-            '0x1bb089c2686c65d8d2e5800761b2826e0fc1f68f7e228fc161384958222bbc271458f40ed77507d59ca77c56204b0134b429eaface39b196d1f07e917a14c7641b',
-        })
+        .send({ signature })
         .expect(200)
     })
     it('returns bad request for invalid input', async () => {
-      await server
+      await createServer()
         .post('/forced/offers/1/cancel')
         .send({
           signature: 123,

--- a/packages/backend/test/peripherals/database/ForcedTradeOfferRepository.test.ts
+++ b/packages/backend/test/peripherals/database/ForcedTradeOfferRepository.test.ts
@@ -45,7 +45,7 @@ function fakeOffer(
 function fakeInitialOffer(
   offer?: Partial<Omit<ForcedTradeOfferRecord, 'accepted'>>
 ) {
-  return fakeOffer({ ...offer, accepted: undefined })
+  return fakeOffer({ ...offer, accepted: undefined, cancelledAt: null })
 }
 
 describe(ForcedTradeOfferRepository.name, () => {

--- a/packages/backend/test/peripherals/database/ForcedTradeOfferRepository.test.ts
+++ b/packages/backend/test/peripherals/database/ForcedTradeOfferRepository.test.ts
@@ -45,7 +45,7 @@ function fakeOffer(
 function fakeInitialOffer(
   offer?: Partial<Omit<ForcedTradeOfferRecord, 'accepted'>>
 ) {
-  return fakeOffer({ ...offer, accepted: undefined, cancelledAt: null })
+  return fakeOffer({ ...offer, accepted: undefined, cancelledAt: undefined })
 }
 
 describe(ForcedTradeOfferRepository.name, () => {

--- a/packages/frontend/src/scripts/offer/sign.ts
+++ b/packages/frontend/src/scripts/offer/sign.ts
@@ -38,7 +38,7 @@ export async function signAccepted(
   address: EthereumAddress
 ): Promise<string | undefined> {
   const toSign = digestAcceptedOfferParams(offer, accepted)
-  return sign('personal_sign', address, toSign)
+  return sign('eth_sign', address, toSign)
 }
 
 export async function signCancel(

--- a/packages/frontend/src/scripts/offer/sign.ts
+++ b/packages/frontend/src/scripts/offer/sign.ts
@@ -1,7 +1,7 @@
 import {
-  digestAcceptedOfferParams,
+  getAcceptRequest,
   getCancelRequest,
-  stringifyInitialOffer,
+  getInitialOfferRequest,
 } from '@explorer/shared'
 import { EthereumAddress } from '@explorer/types'
 
@@ -24,11 +24,11 @@ async function sign(
   }
 }
 
-export async function signInitial(
+export async function signCreate(
   offer: OfferData,
   address: EthereumAddress
 ): Promise<string | undefined> {
-  const toSign = stringifyInitialOffer(offer)
+  const toSign = getInitialOfferRequest(offer)
   return sign('personal_sign', address, toSign)
 }
 
@@ -37,7 +37,7 @@ export async function signAccepted(
   accepted: AcceptedData,
   address: EthereumAddress
 ): Promise<string | undefined> {
-  const toSign = digestAcceptedOfferParams(offer, accepted)
+  const toSign = getAcceptRequest(offer, accepted)
   return sign('eth_sign', address, toSign)
 }
 

--- a/packages/frontend/src/scripts/offer/sign.ts
+++ b/packages/frontend/src/scripts/offer/sign.ts
@@ -1,7 +1,7 @@
 import {
   getAcceptRequest,
   getCancelRequest,
-  getInitialOfferRequest,
+  getCreateRequest,
 } from '@explorer/shared'
 import { EthereumAddress } from '@explorer/types'
 
@@ -28,7 +28,7 @@ export async function signCreate(
   offer: OfferData,
   address: EthereumAddress
 ): Promise<string | undefined> {
-  const toSign = getInitialOfferRequest(offer)
+  const toSign = getCreateRequest(offer)
   return sign('personal_sign', address, toSign)
 }
 

--- a/packages/frontend/src/scripts/transaction/submit.ts
+++ b/packages/frontend/src/scripts/transaction/submit.ts
@@ -1,4 +1,4 @@
-import { signInitial } from '../offer/sign'
+import { signCreate } from '../offer/sign'
 import { FormState } from './types'
 
 export async function submit(state: FormState) {
@@ -17,7 +17,7 @@ export async function submit(state: FormState) {
     aIsBuyingSynthetic: state.buyButtonSelected,
   }
 
-  const signature = await signInitial(offer, state.props.account)
+  const signature = await signCreate(offer, state.props.account)
 
   if (!signature) {
     console.error('Offer parameters need to be signed.')

--- a/packages/shared/src/getAcceptRequest.ts
+++ b/packages/shared/src/getAcceptRequest.ts
@@ -2,7 +2,7 @@ import { keccak256, pack } from '@ethersproject/solidity'
 import { encodeAssetId } from '@explorer/encoding'
 import { AssetId, StarkKey } from '@explorer/types'
 
-export function digestAcceptedOfferParams(
+export function getAcceptRequest(
   offer: {
     starkKeyA: StarkKey
     positionIdA: bigint

--- a/packages/shared/src/getCancelRequest.ts
+++ b/packages/shared/src/getCancelRequest.ts
@@ -1,0 +1,10 @@
+export function getCancelRequest(offerId: number): string {
+  return JSON.stringify(
+    {
+      cancel: true,
+      offerId,
+    },
+    null,
+    2
+  )
+}

--- a/packages/shared/src/getCreateRequest.ts
+++ b/packages/shared/src/getCreateRequest.ts
@@ -1,6 +1,6 @@
 import { AssetId, StarkKey } from '@explorer/types'
 
-export function stringifyInitialOffer(offer: {
+export function getCreateRequest(offer: {
   starkKeyA: StarkKey
   positionIdA: bigint
   syntheticAssetId: AssetId

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,3 @@
-export * from './digestAcceptedOfferParams'
+export * from './getAcceptRequest'
 export * from './getCancelRequest'
-export * from './stringifyInitialOffer'
+export * from './getCreateRequest'

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from './digestAcceptedOfferParams'
+export * from './getCancelRequest'
 export * from './stringifyInitialOffer'

--- a/packages/shared/test/getAcceptRequest.test.ts
+++ b/packages/shared/test/getAcceptRequest.test.ts
@@ -2,7 +2,7 @@ import { recoverAddress } from '@ethersproject/transactions'
 import { AssetId, StarkKey } from '@explorer/types'
 import { expect } from 'earljs'
 
-import { digestAcceptedOfferParams } from '../src'
+import { getAcceptRequest } from '../src'
 
 // Mock data taken from real transaction:https://etherscan.io/tx/0x9b2dce5538d0c8c08511c9383be9b67da6f952b367baff0c8bdb5f66c9395634
 
@@ -31,9 +31,9 @@ const ACCEPTED = {
 
 const ETH_ADDRESS = '0xCE9a3e51B905997F1D098345a92B6c749A1f72B9'
 
-describe(digestAcceptedOfferParams.name, () => {
+describe(getAcceptRequest.name, () => {
   it('works on an example tx', () => {
-    const digest = digestAcceptedOfferParams(INITIAL, ACCEPTED)
+    const digest = getAcceptRequest(INITIAL, ACCEPTED)
     expect(recoverAddress(digest, ACCEPTED.signature)).toEqual(ETH_ADDRESS)
   })
 })

--- a/packages/shared/test/getCancelRequest.test.ts
+++ b/packages/shared/test/getCancelRequest.test.ts
@@ -1,0 +1,11 @@
+import { expect } from 'earljs'
+
+import { getCancelRequest } from '../src'
+
+describe(getCancelRequest.name, () => {
+  it('works properly', () => {
+    expect(getCancelRequest(1)).toEqual(
+      ['{', `  "cancel": true,`, `  "offerId": 1`, '}'].join('\n')
+    )
+  })
+})

--- a/packages/shared/test/getCreateRequest.ts
+++ b/packages/shared/test/getCreateRequest.ts
@@ -1,7 +1,7 @@
 import { AssetId, StarkKey } from '@explorer/types'
 import { expect } from 'earljs'
 
-import { stringifyInitialOffer } from '../src'
+import { getCreateRequest } from '../src'
 
 const offer = {
   starkKeyA: StarkKey.fake(),
@@ -12,9 +12,9 @@ const offer = {
   aIsBuyingSynthetic: true,
 }
 
-describe(stringifyInitialOffer.name, () => {
+describe(getCreateRequest.name, () => {
   it('works properly', () => {
-    expect(stringifyInitialOffer(offer)).toEqual(
+    expect(getCreateRequest(offer)).toEqual(
       [
         '{',
         `  "starkKeyA": "${offer.starkKeyA}",`,


### PR DESCRIPTION
This is only the backend for cancellations - connecting the UI will be easier once the UI for cancel buttons will be added, but it is still just a button POST'ing to the api and redirecting.

Note: what is the simplest way of getting a signature of cancel request for the purpose of automated tests?